### PR TITLE
Removed use of BaseDistribution

### DIFF
--- a/CHANGES/8745.misc
+++ b/CHANGES/8745.misc
@@ -1,0 +1,1 @@
+Removed use of BaseDistribution for compatibility with pulpcore 3.13.

--- a/pulp_maven/app/migrations/0004_swap_distribution_models.py
+++ b/pulp_maven/app/migrations/0004_swap_distribution_models.py
@@ -1,0 +1,77 @@
+from django.db import migrations, models, transaction
+import django.db.models.deletion
+
+
+def migrate_data_from_old_model_to_new_model_up(apps, schema_editor):
+    """ Move objects from MavenDistribution to NewMavenDistribution."""
+    MavenDistribution = apps.get_model('maven', 'MavenDistribution')
+    NewMavenDistribution = apps.get_model('maven', 'NewMavenDistribution')
+    for maven_distribution in MavenDistribution.objects.all():
+        with transaction.atomic():
+            NewMavenDistribution(
+                pulp_id=maven_distribution.pulp_id,
+                pulp_created=maven_distribution.pulp_created,
+                pulp_last_updated=maven_distribution.pulp_last_updated,
+                pulp_type=maven_distribution.pulp_type,
+                name=maven_distribution.name,
+                base_path=maven_distribution.base_path,
+                content_guard=maven_distribution.content_guard,
+                remote=maven_distribution.remote,
+                repository_version=maven_distribution.repository_version,
+                repository=maven_distribution.repository
+            ).save()
+            maven_distribution.delete()
+
+
+def migrate_data_from_old_model_to_new_model_down(apps, schema_editor):
+    """ Move objects from NewMavenDistribution to MavenDistribution."""
+    MavenDistribution = apps.get_model('maven', 'MavenDistribution')
+    NewMavenDistribution = apps.get_model('maven', 'NewMavenDistribution')
+    for maven_distribution in NewMavenDistribution.objects.all():
+        with transaction.atomic():
+            MavenDistribution(
+                pulp_id=maven_distribution.pulp_id,
+                pulp_created=maven_distribution.pulp_created,
+                pulp_last_updated=maven_distribution.pulp_last_updated,
+                pulp_type=maven_distribution.pulp_type,
+                name=maven_distribution.name,
+                base_path=maven_distribution.base_path,
+                content_guard=maven_distribution.content_guard,
+                remote=maven_distribution.remote,
+                repository_version=maven_distribution.repository_version,
+                repository=maven_distribution.repository
+            ).save()
+            maven_distribution.delete()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ('core', '0062_add_new_distribution_mastermodel'),
+        ('maven', '0003_mavenrepository'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='NewMavenDistribution',
+            fields=[
+                ('distribution_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, related_name='maven_mavendistribution', serialize=False, to='core.Distribution')),
+            ],
+            options={
+                'default_related_name': '%(app_label)s_%(model_name)s',
+            },
+            bases=('core.distribution',),
+        ),
+        migrations.RunPython(
+            code=migrate_data_from_old_model_to_new_model_up,
+            reverse_code=migrate_data_from_old_model_to_new_model_down,
+        ),
+        migrations.DeleteModel(
+            name='MavenDistribution',
+        ),
+        migrations.RenameModel(
+            old_name='NewMavenDistribution',
+            new_name='MavenDistribution',
+        ),
+    ]

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -4,7 +4,7 @@ from os import path
 
 from django.db import models
 
-from pulpcore.plugin.models import Content, Remote, Repository, BaseDistribution
+from pulpcore.plugin.models import Content, Remote, Repository, Distribution
 
 logger = getLogger(__name__)
 
@@ -100,7 +100,7 @@ class MavenRemote(Remote):
         default_related_name = "%(app_label)s_%(model_name)s"
 
 
-class MavenDistribution(BaseDistribution):
+class MavenDistribution(Distribution):
     """
     Distribution for 'maven' content.
     """

--- a/pulp_maven/app/serializers.py
+++ b/pulp_maven/app/serializers.py
@@ -62,7 +62,7 @@ class MavenRemoteSerializer(platform.RemoteSerializer):
         model = models.MavenRemote
 
 
-class MavenDistributionSerializer(platform.BaseDistributionSerializer):
+class MavenDistributionSerializer(platform.DistributionSerializer):
     """
     Serializer for Maven Distributions.
     """
@@ -75,5 +75,5 @@ class MavenDistributionSerializer(platform.BaseDistributionSerializer):
     )
 
     class Meta:
-        fields = platform.BaseDistributionSerializer.Meta.fields + ("remote",)
+        fields = platform.DistributionSerializer.Meta.fields + ("remote",)
         model = models.MavenDistribution

--- a/pulp_maven/app/viewsets.py
+++ b/pulp_maven/app/viewsets.py
@@ -52,7 +52,7 @@ class MavenRepositoryVersionViewSet(core.RepositoryVersionViewSet):
     parent_viewset = MavenRepositoryViewSet
 
 
-class MavenDistributionViewSet(core.BaseDistributionViewSet):
+class MavenDistributionViewSet(core.DistributionViewSet):
     """
     ViewSet for Maven Distributions.
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pulpcore>=3.1
+pulpcore>=3.12.1


### PR DESCRIPTION
pulpcore 3.12 deprecated use of BaseDistribution. This patch makes pulp_maven compatible
with the upcoming pulpcore 3.13 release where BaseDistribution is fully removed.

fixes: #8745
https://pulp.plan.io/issues/8745