### PR TITLE
Use immediate tasks for deploy api

### DIFF
--- a/CHANGES/+use_immediate_task.feature
+++ b/CHANGES/+use_immediate_task.feature
@@ -1,0 +1,1 @@
+Changed the deploy api to use non blocking immediate tasks.


### PR DESCRIPTION
This will not block up to three seconds.

[noissue]