### PR TITLE
Add an option to build Markdown files from rst documentation

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -9,6 +9,7 @@ plantuml
 sphinx~=7.1.2
 sphinx-rtd-theme==1.3.0
 sphinxcontrib-jquery
+sphinx-markdown-builder
 sphinxcontrib-openapi
 towncrier
 mistune<4.0.0

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -193,3 +193,8 @@ doctest:
 
 run:
 	cd $(BUILDDIR) && python -m http.server 8010
+
+markdown:
+	$(SPHINXBUILD) -b markdown $(ALLSPHINXOPTS) $(BUILDDIR)/markdown
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinxcontrib.openapi',
     'sphinxcontrib.jquery',
+    'sphinx_markdown_builder'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This is a quick experiment to understand how we can generate markdown from rst files

Please, do not merge this.
I repeat: do not merge this.

[noissue]
