### PR TITLE
Fixes deploy to pulp test

### DIFF
--- a/pulp_maven/tests/assets/simple-project/pom.xml
+++ b/pulp_maven/tests/assets/simple-project/pom.xml
@@ -32,6 +32,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+            <source>11</source>
+            <target>11</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.4</version>
         <dependencies>

--- a/pulp_maven/tests/functional/api/test_mvn_deploy.py
+++ b/pulp_maven/tests/functional/api/test_mvn_deploy.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import subprocess
 from urllib.parse import urljoin
 from pulp_maven.tests.functional.utils import download_file
@@ -24,18 +25,17 @@ def test_mvn_deploy_workflow(
             ["sed", "-i", f"s/maven-snapshots/{repo.name}/g", f"{tmp_path}/simple-project/pom.xml"]
         )
         # Run mvn deploy
-        result = subprocess.run(
+        subprocess.run(
             ["mvn", "deploy"],
             cwd=f"{tmp_path}/simple-project",
-            check=False,
+            check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        print(result.stdout.decode())
-        print(result.stderr.decode())
     except subprocess.CalledProcessError as e:
         # The command had a non-zero exit code
-        print(e.stderr.decode())
+        msg = e.stdout.decode() + e.stderr.decode()
+        pytest.fail(msg)
 
     # Assert that the latest version is 12
     repo = maven_repo_api_client.read(repo.pulp_href)


### PR DESCRIPTION
The project builds against a really old version of java by default. This change ensures that the build target is for Java 11.

The test was also updated to fail immediately after a failed build.

[noissue]