### PR TITLE
Fix Maven version parsing for non-numeric versions

### DIFF
--- a/CHANGES/338.bugfix
+++ b/CHANGES/338.bugfix
@@ -1,0 +1,1 @@
+Fixed Maven version parsing so non-numeric versions (e.g. RELEASE, master-SNAPSHOT, INT-7144.1.0.2) are no longer misparsed as the artifactId with a null version, which caused HTTP 500 on upload.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -13,12 +13,19 @@ logger = getLogger(__name__)
 
 class MavenContentMixin:
     @staticmethod
-    def group_artifact_version_filename(relative_path):
+    def group_artifact_version_filename(relative_path, version_present=None):
         """
         Converts a relative path into a tuple of group_id, artifact_id, and version.
 
         Args:
             relative_path (str): Relative path for the artifact in the repository.
+            version_present (bool): Whether the path is known to contain a
+                version directory. Binary artifacts (jar/pom/war/...) always do
+                in the standard Maven layout, so callers handling them should
+                pass ``True``. ``None`` (the default) keeps the legacy
+                best-effort detection, used for metadata where an artifact-level
+                ``maven-metadata.xml`` lives directly under the artifactId with
+                no version directory.
 
         Returns:
             Tuple (group_id, artifact_id, version, filename)
@@ -26,13 +33,21 @@ class MavenContentMixin:
         """
         sub_path, filename = path.split(relative_path)
         sub_path, version = path.split(sub_path)
-        pattern = re.compile(r"\d+(\.\d+)?(\.\d+)?([.-][a-zA-Z0-9]+)*")
-        if pattern.match(version) is None:
-            artifact_id = version
-            version = None
+        if version_present is None:
+            # Legacy heuristic. A Maven version is a free-form string, so a
+            # numeric-only pattern misclassifies valid non-numeric versions
+            # (e.g. "RELEASE", "master-SNAPSHOT", "INT-7144.1.0.2"): they are
+            # mistaken for the artifactId and ``version`` becomes ``None``.
+            # Callers that know a version directory is present should pass
+            # version_present=True to skip this guess.
+            pattern = re.compile(r"\d+(\.\d+)?(\.\d+)?([.-][a-zA-Z0-9]+)*")
+            version_present = pattern.match(version) is not None
+        if version_present:
+            sub_path, artifact_id = path.split(sub_path)
             group_id = sub_path.replace("/", ".")
         else:
-            sub_path, artifact_id = path.split(sub_path)
+            artifact_id = version
+            version = None
             group_id = sub_path.replace("/", ".")
 
         return group_id, artifact_id, version, filename
@@ -71,7 +86,7 @@ class MavenArtifact(MavenContentMixin, Content):
             raise ValueError(_("Relative path can't start with '/'."))
 
         group_id, artifact_id, version, f_name = MavenArtifact.group_artifact_version_filename(
-            relative_path
+            relative_path, version_present=True
         )
 
         return MavenArtifact(

--- a/pulp_maven/tests/unit/test_path_parsing.py
+++ b/pulp_maven/tests/unit/test_path_parsing.py
@@ -1,0 +1,42 @@
+import pytest
+
+from pulp_maven.app.models import MavenArtifact
+
+
+@pytest.mark.parametrize(
+    "relative_path,expected",
+    [
+        # (group_id, artifact_id, version, filename)
+        (
+            "com/example/myapp/1.0.0/myapp-1.0.0.jar",
+            ("com.example", "myapp", "1.0.0", "myapp-1.0.0.jar"),
+        ),
+        # Non-numeric versions must NOT be misparsed as artifactId/version=None.
+        (
+            "com/example/myapp/RELEASE/myapp-RELEASE.jar",
+            ("com.example", "myapp", "RELEASE", "myapp-RELEASE.jar"),
+        ),
+        (
+            "com/example/myapp/master-SNAPSHOT/myapp-master-SNAPSHOT.jar",
+            ("com.example", "myapp", "master-SNAPSHOT", "myapp-master-SNAPSHOT.jar"),
+        ),
+        (
+            "com/vsware/svc/INT-7144.1.0.2/svc-INT-7144.1.0.2.jar",
+            ("com.vsware.svc", "svc", "INT-7144.1.0.2", "svc-INT-7144.1.0.2.jar"),
+        ),
+    ],
+)
+def test_binary_artifact_version_present(relative_path, expected):
+    assert (
+        MavenArtifact.group_artifact_version_filename(relative_path, version_present=True)
+        == expected
+    )
+
+
+def test_artifact_level_metadata_has_no_version():
+    # Legacy best-effort path (version_present=None): artifact-level
+    # maven-metadata.xml sits directly under the artifactId, no version dir.
+    g, a, v, f = MavenArtifact.group_artifact_version_filename(
+        "com/example/myapp/maven-metadata.xml"
+    )
+    assert (g, a, v, f) == ("com.example", "myapp", None, "maven-metadata.xml")


### PR DESCRIPTION
## Problem

`MavenContentMixin.group_artifact_version_filename()` decides whether a path
contains a version directory by matching the candidate segment against a
numeric-anchored regex (`re.match(r"\d+...")`). Maven versions are free-form,
so any version not starting with a digit — `RELEASE`, `master-SNAPSHOT`,
JIRA-tagged `INT-7144.1.0.2`, etc. — is misclassified: the version segment is
taken as the `artifactId`, `version` becomes `None`, and the upload fails with
a NOT NULL violation → HTTP 500 on `PUT /pulp/maven/<distribution>/<path>`.

Fixes #

## Fix

The content type is already known upstream
(`MavenRemote.get_remote_artifact_content_type()` routes `.xml*` to
`MavenMetadata`, everything else to `MavenArtifact`). A binary artifact in
standard Maven layout always has a version directory, so the regex guess is
unnecessary and wrong there. This PR adds a `version_present` argument:

- `MavenArtifact` passes `version_present=True` — version directory is always
  present, no guessing.
- `MavenMetadata` and any other caller keep the existing best-effort detection
  (default `version_present=None`), so artifact-level `maven-metadata.xml`
  (which has no version directory) is unchanged.

No behavior change for numeric versions or for metadata; non-numeric artifact
versions now parse correctly.

## Tests

Added `pulp_maven/tests/unit/test_path_parsing.py` covering numeric and
non-numeric versions plus the artifact-level-metadata (no-version) case.

## Changelog

`CHANGES/.bugfix` added.
