### PR TITLE
Add file upload support to Maven Artifact create API

### DIFF
--- a/CHANGES/348.feature
+++ b/CHANGES/348.feature
@@ -1,0 +1,1 @@
+The Maven Artifact create API now accepts file uploads in addition to artifact hrefs.

--- a/docs/user/guides/upload.md
+++ b/docs/user/guides/upload.md
@@ -1,0 +1,157 @@
+# Upload Maven Artifacts
+
+Maven artifacts can be uploaded to Pulp using the content create API.
+The API accepts either a file upload or a reference to a pre-uploaded artifact.
+
+When uploading multiple artifacts, the recommended workflow is:
+
+1. Upload all content units in parallel (without specifying a repository)
+2. Add them all to a repository in a single request using the repository modify API
+
+This avoids 429 throttling from repository locking during parallel uploads.
+
+## Prerequisites
+
+Create a Maven repository and distribution to serve the uploaded content:
+
+=== "run"
+
+    ```bash
+    pulp maven repository create --name maven-releases
+    pulp maven distribution create --name maven-releases --repository maven-releases --base-path maven-releases
+    ```
+
+## Upload a file directly
+
+Upload an artifact file using the `file` field:
+
+```bash
+curl -u admin:password -X POST \
+  http://pulp-hostname/pulp/api/v3/content/maven/artifact/ \
+  -F "file=@spring-cloud-config-server-4.3.0-redhat-1.jar" \
+  -F "relative_path=org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1/spring-cloud-config-server-4.3.0-redhat-1.jar" \
+  -F 'pulp_labels={"vendor": "redhat", "verified": "true"}'
+```
+
+The `relative_path` must follow Maven repository layout conventions:
+`<group_id_as_path>/<artifact_id>/<version>/<filename>`.
+
+The `group_id`, `artifact_id`, `version`, and `filename` fields are automatically extracted from the `relative_path`.
+
+The optional `pulp_labels` field accepts a JSON dictionary of key/value pairs for tagging content units. Labels can be used to filter and organize content.
+
+## Upload using a pre-uploaded artifact
+
+If you have already uploaded an artifact to the Pulp artifacts API, reference it by href:
+
+```bash
+# First, upload the file as an artifact
+curl -u admin:password -X POST \
+  http://pulp-hostname/pulp/api/v3/artifacts/ \
+  -F "file=@spring-cloud-config-server-4.3.0-redhat-1.jar"
+
+# Then create the Maven content unit referencing the artifact
+curl -u admin:password -X POST \
+  http://pulp-hostname/pulp/api/v3/content/maven/artifact/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "artifact": "/pulp/api/v3/artifacts/<uuid>/",
+    "relative_path": "org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1/spring-cloud-config-server-4.3.0-redhat-1.jar",
+    "pulp_labels": {"vendor": "redhat", "verified": "true"}
+  }'
+```
+
+## Upload using the Python client
+
+```python
+from pulpcore.client.pulp_maven import ApiClient, ContentArtifactApi, Configuration
+
+configuration = Configuration(
+    host="http://pulp-hostname",
+    username="admin",
+    password="password",
+)
+client = ApiClient(configuration)
+api = ContentArtifactApi(client)
+
+content = api.create(
+    file="/path/to/spring-cloud-config-server-4.3.0-redhat-1.jar",
+    relative_path="org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1/spring-cloud-config-server-4.3.0-redhat-1.jar",
+    pulp_labels={"vendor": "redhat", "verified": "true"},
+)
+print(content.group_id)      # org.springframework.cloud
+print(content.artifact_id)   # spring-cloud-config-server
+print(content.version)       # 4.3.0-redhat-1
+print(content.filename)      # spring-cloud-config-server-4.3.0-redhat-1.jar
+print(content.pulp_labels)   # {'vendor': 'redhat', 'verified': 'true'}
+```
+
+## Adding content to a repository
+
+After uploading content units, add them to a repository using the modify API.
+This approach allows you to upload many artifacts in parallel and then add them
+all in a single repository version:
+
+```bash
+curl -u admin:password -X POST \
+  http://pulp-hostname/pulp/api/v3/repositories/maven/maven/<uuid>/modify/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "add_content_units": [
+      "/pulp/api/v3/content/maven/artifact/<uuid-1>/",
+      "/pulp/api/v3/content/maven/artifact/<uuid-2>/",
+      "/pulp/api/v3/content/maven/artifact/<uuid-3>/"
+    ]
+  }'
+```
+
+Using the Python client:
+
+```python
+from pulpcore.client.pulp_maven import RepositoriesMavenApi
+
+repo_api = RepositoriesMavenApi(client)
+repo_api.modify(
+    maven_maven_repository_href="/pulp/api/v3/repositories/maven/maven/<uuid>/",
+    repository_add_remove_content={
+        "add_content_units": [c.pulp_href for c in uploaded_content],
+    },
+)
+```
+
+## Upload and add to a repository in one request
+
+You can also specify a `repository` parameter on the create request to upload and add the
+content to a repository in a single call. When a repository is specified, the content is
+added via an immediate task that requires an exclusive lock on the repository. If the lock
+cannot be acquired (e.g. another upload is in progress), the API returns **429 Too Many Requests**.
+
+Callers should implement retry logic with backoff when using this approach:
+
+```bash
+upload_with_retry() {
+  local max_retries=5
+  local attempt=0
+  while [ $attempt -lt $max_retries ]; do
+    status=$(curl -s -o /dev/null -w "%{http_code}" -u admin:password -X POST \
+      http://pulp-hostname/pulp/api/v3/content/maven/artifact/ \
+      -F "file=@$1" \
+      -F "relative_path=$2" \
+      -F "repository=$3")
+    if [ "$status" = "201" ]; then
+      return 0
+    elif [ "$status" = "429" ]; then
+      attempt=$((attempt + 1))
+      sleep $((attempt * 2))
+    else
+      echo "Error: HTTP $status"
+      return 1
+    fi
+  done
+  echo "Failed after $max_retries retries"
+  return 1
+}
+```
+
+For uploading many artifacts, the batch approach described in the previous section is
+preferred as it avoids the 429 throttling entirely.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -26,7 +26,7 @@ class MavenContentMixin:
         """
         sub_path, filename = path.split(relative_path)
         sub_path, version = path.split(sub_path)
-        pattern = re.compile(r"\d+(\.\d+)?(\.\d+)?([.-][a-zA-Z0-9]+)*")
+        pattern = re.compile(r"(?=.*\d)[a-zA-Z0-9]+([.-][a-zA-Z0-9]+)*")
         if pattern.match(version) is None:
             artifact_id = version
             version = None

--- a/pulp_maven/app/serializers.py
+++ b/pulp_maven/app/serializers.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 from rest_framework import serializers
 
 from pulpcore.plugin import serializers as platform
+from pulpcore.plugin.models import Artifact
 
 from . import models
 
@@ -22,6 +23,11 @@ class MavenArtifactSerializer(platform.SingleArtifactContentSerializer):
     A Serializer for MavenArtifact.
     """
 
+    file = serializers.FileField(
+        help_text=_("An uploaded file that may be turned into the content unit."),
+        required=False,
+        write_only=True,
+    )
     group_id = serializers.CharField(
         help_text=_("Group Id of the artifact's package."), read_only=True
     )
@@ -33,8 +39,45 @@ class MavenArtifactSerializer(platform.SingleArtifactContentSerializer):
     )
     filename = serializers.CharField(help_text=_("Filename of the artifact."), read_only=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if "artifact" in self.fields:
+            self.fields["artifact"].required = False
+
+    def validate(self, data):
+        if "file" not in data and "artifact" not in data:
+            raise serializers.ValidationError(_("Either 'file' or 'artifact' must be provided."))
+        if "file" in data and "artifact" in data:
+            raise serializers.ValidationError(
+                _("Only one of 'file' or 'artifact' may be provided.")
+            )
+        return super().validate(data)
+
+    def create(self, validated_data):
+        file = validated_data.pop("file", None)
+        if file:
+            artifact = Artifact.init_and_validate(file)
+            try:
+                artifact = Artifact.objects.get(
+                    sha256=artifact.sha256, pulp_domain=artifact.pulp_domain
+                )
+                artifact.touch()
+            except Artifact.DoesNotExist:
+                artifact.save()
+            validated_data["artifact"] = artifact
+
+        group_id, artifact_id, version, filename = (
+            models.MavenArtifact.group_artifact_version_filename(validated_data["relative_path"])
+        )
+        validated_data["group_id"] = group_id
+        validated_data["artifact_id"] = artifact_id
+        validated_data["version"] = version
+        validated_data["filename"] = filename
+        return super().create(validated_data)
+
     class Meta:
         fields = platform.SingleArtifactContentSerializer.Meta.fields + (
+            "file",
             "group_id",
             "artifact_id",
             "version",

--- a/pulp_maven/app/viewsets.py
+++ b/pulp_maven/app/viewsets.py
@@ -1,5 +1,8 @@
+from django.db import transaction
 from drf_spectacular.utils import extend_schema
+from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from pulpcore.plugin.actions import ModifyRepositoryActionMixin
 from pulpcore.plugin.serializers import AsyncOperationResponseSerializer
@@ -14,6 +17,7 @@ from pulpcore.plugin.viewsets import (
     RepositoryViewSet,
 )
 
+from pulp_maven.app.maven_deploy_api import has_task_completed
 from pulp_maven.app.models import MavenArtifact, MavenDistribution, MavenRemote, MavenRepository
 from pulp_maven.app.serializers import (
     MavenArtifactSerializer,
@@ -22,7 +26,7 @@ from pulp_maven.app.serializers import (
     MavenRepositorySerializer,
     RepositoryAddCachedContentSerializer,
 )
-from pulp_maven.app.tasks import add_cached_content_to_repository
+from pulp_maven.app.tasks import aadd_and_remove, add_cached_content_to_repository
 
 
 class MavenArtifactFilter(ContentFilter):
@@ -44,6 +48,31 @@ class MavenArtifactViewSet(ContentViewSet):
     queryset = MavenArtifact.objects.all()
     serializer_class = MavenArtifactSerializer
     filterset_class = MavenArtifactFilter
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        repository = serializer.validated_data.pop("repository", None)
+        with transaction.atomic():
+            serializer.save()
+
+        if repository:
+            dispatched_task = dispatch(
+                aadd_and_remove,
+                exclusive_resources=[repository],
+                immediate=True,
+                deferred=False,
+                kwargs={
+                    "repository_pk": str(repository.pk),
+                    "add_content_units": [str(serializer.instance.pk)],
+                    "remove_content_units": [],
+                },
+            )
+            has_task_completed(dispatched_task)
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
 
 class MavenRemoteViewSet(RemoteViewSet):

--- a/pulp_maven/tests/functional/api/test_create_content.py
+++ b/pulp_maven/tests/functional/api/test_create_content.py
@@ -1,0 +1,229 @@
+import hashlib
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urljoin
+
+import pytest
+
+from pulpcore.client.pulp_maven.exceptions import ApiException
+
+from pulp_maven.tests.functional.utils import download_file
+
+FILENAMES = [
+    "spring-cloud-config-server-4.3.0-redhat-1.jar",
+    "spring-cloud-config-server-4.3.0-redhat-1.jar.md5",
+    "spring-cloud-config-server-4.3.0-redhat-1.jar.sha1",
+    "spring-cloud-config-server-4.3.0-redhat-1.jar.sha256",
+    "spring-cloud-config-server-4.3.0-redhat-1.pom",
+    "spring-cloud-config-server-4.3.0-redhat-1.pom.md5",
+    "spring-cloud-config-server-4.3.0-redhat-1.pom.sha1",
+    "spring-cloud-config-server-4.3.0-redhat-1.pom.sha256",
+    "spring-cloud-config-server-4.3.0-redhat-1-cyclonedx.json",
+    "spring-cloud-config-server-4.3.0-redhat-1-cyclonedx.json.md5",
+    "spring-cloud-config-server-4.3.0-redhat-1-cyclonedx.json.sha1",
+    "spring-cloud-config-server-4.3.0-redhat-1-cyclonedx.json.sha256",
+    "spring-cloud-config-server-4.3.0-redhat-1-provenance.json",
+    "spring-cloud-config-server-4.3.0-redhat-1-provenance.json.md5",
+    "spring-cloud-config-server-4.3.0-redhat-1-provenance.json.sha1",
+    "spring-cloud-config-server-4.3.0-redhat-1-provenance.json.sha256",
+    "spring-cloud-config-server-4.3.0-redhat-1-vex.json",
+    "spring-cloud-config-server-4.3.0-redhat-1-vex.json.md5",
+    "spring-cloud-config-server-4.3.0-redhat-1-vex.json.sha1",
+    "spring-cloud-config-server-4.3.0-redhat-1-vex.json.sha256",
+]
+
+GROUP_PATH = "org/springframework/cloud/spring-cloud-config-server/4.3.0-redhat-1"
+EXPECTED_GROUP_ID = "org.springframework.cloud"
+EXPECTED_ARTIFACT_ID = "spring-cloud-config-server"
+EXPECTED_VERSION = "4.3.0-redhat-1"
+
+
+@pytest.mark.parallel
+def test_create_maven_artifacts(
+    maven_artifact_api_client,
+    random_artifact_factory,
+    maven_repo_factory,
+    maven_distribution_factory,
+    distribution_base_url,
+):
+    """Test creating MavenArtifact content units and downloading them."""
+    repo = maven_repo_factory()
+    distribution = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distribution.base_url)
+
+    artifact_data = {}
+    for filename in FILENAMES:
+        artifact = random_artifact_factory(size=64)
+        artifact_data[filename] = artifact.sha256
+        relative_path = f"{GROUP_PATH}/{filename}"
+        content = maven_artifact_api_client.create(
+            artifact=artifact.pulp_href,
+            relative_path=relative_path,
+            repository=repo.pulp_href,
+        )
+        assert content.pulp_href is not None
+        content = maven_artifact_api_client.read(content.pulp_href)
+        assert content.group_id == EXPECTED_GROUP_ID
+        assert content.artifact_id == EXPECTED_ARTIFACT_ID
+        assert content.version == EXPECTED_VERSION
+        assert content.filename == filename
+
+    for filename, expected_sha256 in artifact_data.items():
+        unit_url = urljoin(base_url, f"{GROUP_PATH}/{filename}")
+        downloaded = download_file(unit_url)
+        assert downloaded.response_obj.status == 200
+        actual_sha256 = hashlib.sha256(downloaded.body).hexdigest()
+        assert actual_sha256 == expected_sha256
+
+
+@pytest.mark.parallel
+def test_create_maven_artifact_rhlw_version(
+    maven_artifact_api_client,
+    random_artifact_factory,
+    maven_repo_factory,
+    maven_distribution_factory,
+    distribution_base_url,
+):
+    """Test creating a MavenArtifact with an rhlw-style version string."""
+    repo = maven_repo_factory()
+    distribution = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distribution.base_url)
+
+    filename = "spring-security-core-5.3.17.rhlw-00001.jar"
+    relative_path = (
+        "org/springframework/security/spring-security-core/5.3.17.rhlw-00001/" + filename
+    )
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.create(
+        artifact=artifact.pulp_href,
+        relative_path=relative_path,
+        repository=repo.pulp_href,
+    )
+    content = maven_artifact_api_client.read(content.pulp_href)
+    assert content.group_id == "org.springframework.security"
+    assert content.artifact_id == "spring-security-core"
+    assert content.version == "5.3.17.rhlw-00001"
+    assert content.filename == filename
+
+    unit_url = urljoin(base_url, relative_path)
+    downloaded = download_file(unit_url)
+    assert downloaded.response_obj.status == 200
+    assert hashlib.sha256(downloaded.body).hexdigest() == artifact.sha256
+
+
+@pytest.mark.parallel
+def test_create_maven_artifact_text_prefixed_version(
+    maven_artifact_api_client,
+    random_artifact_factory,
+    maven_repo_factory,
+    maven_distribution_factory,
+    distribution_base_url,
+):
+    """Test creating a MavenArtifact with a text-prefixed version string."""
+    repo = maven_repo_factory()
+    distribution = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distribution.base_url)
+
+    filename = "my-lib-final-1.2.3.jar"
+    relative_path = f"com/example/my-lib/final-1.2.3/{filename}"
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.create(
+        artifact=artifact.pulp_href,
+        relative_path=relative_path,
+        repository=repo.pulp_href,
+    )
+    content = maven_artifact_api_client.read(content.pulp_href)
+    assert content.group_id == "com.example"
+    assert content.artifact_id == "my-lib"
+    assert content.version == "final-1.2.3"
+    assert content.filename == filename
+
+    unit_url = urljoin(base_url, relative_path)
+    downloaded = download_file(unit_url)
+    assert downloaded.response_obj.status == 200
+    assert hashlib.sha256(downloaded.body).hexdigest() == artifact.sha256
+
+
+@pytest.mark.parallel
+def test_create_maven_artifact_with_file_upload(
+    maven_artifact_api_client,
+    maven_repo_factory,
+    maven_distribution_factory,
+    distribution_base_url,
+    tmp_path,
+):
+    """Test creating a MavenArtifact by uploading a file directly."""
+    repo = maven_repo_factory()
+    distribution = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distribution.base_url)
+
+    filename = "my-library-1.0.0.jar"
+    relative_path = f"com/example/my-library/1.0.0/{filename}"
+
+    file_content = os.urandom(128)
+    temp_file = tmp_path / filename
+    temp_file.write_bytes(file_content)
+    expected_sha256 = hashlib.sha256(file_content).hexdigest()
+
+    content = maven_artifact_api_client.create(
+        relative_path=relative_path,
+        file=str(temp_file),
+        repository=repo.pulp_href,
+    )
+    content = maven_artifact_api_client.read(content.pulp_href)
+    assert content.group_id == "com.example"
+    assert content.artifact_id == "my-library"
+    assert content.version == "1.0.0"
+    assert content.filename == filename
+
+    unit_url = urljoin(base_url, relative_path)
+    downloaded = download_file(unit_url)
+    assert downloaded.response_obj.status == 200
+    assert hashlib.sha256(downloaded.body).hexdigest() == expected_sha256
+
+
+@pytest.mark.parallel
+def test_create_maven_artifacts_parallel(
+    maven_artifact_api_client,
+    random_artifact_factory,
+    maven_repo_factory,
+    pulp_settings,
+):
+    """Test parallel uploads to the same repo succeed or return 429 (never 500)."""
+    if pulp_settings.WORKER_TYPE != "redis":
+        pytest.skip("Immediate tasks require WORKER_TYPE=redis")
+
+    repo = maven_repo_factory()
+
+    artifacts = []
+    for i in range(20):
+        artifact = random_artifact_factory(size=64)
+        filename = f"lib-{i}-1.0.0.jar"
+        relative_path = f"com/example/lib-{i}/1.0.0/{filename}"
+        artifacts.append((artifact.pulp_href, relative_path))
+
+    throttled_count = 0
+    success_count = 0
+
+    def upload(artifact_href, relative_path):
+        return maven_artifact_api_client.create(
+            artifact=artifact_href,
+            relative_path=relative_path,
+            repository=repo.pulp_href,
+        )
+
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        futures = {executor.submit(upload, href, path): (href, path) for href, path in artifacts}
+        for future in as_completed(futures):
+            try:
+                future.result()
+                success_count += 1
+            except ApiException as e:
+                if e.status == 429:
+                    throttled_count += 1
+                else:
+                    raise
+
+    assert success_count + throttled_count == 20
+    assert success_count >= 1
+    assert throttled_count >= 1, "Expected at least one 429 response from parallel uploads"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "pulpcore>=3.73.0,<3.115",
+  "pulpcore>=3.108.0,<3.115",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- The Maven Artifact create API now accepts a `file` field for direct file uploads, in addition to the existing `artifact` href
- Fields `group_id`, `artifact_id`, `version`, and `filename` are now correctly populated from `relative_path` during creation (previously left empty)
- When a `repository` is specified, content is added via an immediate task (same pattern as the Maven deploy API)

## Test plan
- [x] `test_create_maven_artifacts` — creates 20 artifacts via artifact href, adds to repo, verifies fields and downloads all via content app
- [x] `test_create_maven_artifact_rhlw_version` — creates artifact with `5.3.17.rhlw-00001` version, verifies fields and download
- [x] `test_create_maven_artifact_with_file_upload` — uploads file directly, verifies fields and download

Fixes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)