### PR TITLE
Add label support to Maven Artifact create API

### DIFF
--- a/pulp_maven/app/serializers.py
+++ b/pulp_maven/app/serializers.py
@@ -1,3 +1,4 @@
+import json
 from gettext import gettext as _
 
 from rest_framework import serializers
@@ -40,6 +41,17 @@ class MavenArtifactSerializer(platform.SingleArtifactContentSerializer):
     filename = serializers.CharField(help_text=_("Filename of the artifact."), read_only=True)
 
     def __init__(self, *args, **kwargs):
+        if (
+            "data" in kwargs
+            and "pulp_labels" in kwargs["data"]
+            and isinstance(kwargs["data"]["pulp_labels"], str)
+        ):
+            try:
+                data = kwargs["data"].copy()
+                data["pulp_labels"] = json.loads(data["pulp_labels"])
+                kwargs["data"] = data
+            except (json.JSONDecodeError, AttributeError):
+                pass
         super().__init__(*args, **kwargs)
         if "artifact" in self.fields:
             self.fields["artifact"].required = False

--- a/pulp_maven/tests/functional/api/test_create_content.py
+++ b/pulp_maven/tests/functional/api/test_create_content.py
@@ -56,10 +56,25 @@ def test_create_maven_artifacts(
         artifact = random_artifact_factory(size=64)
         artifact_data[filename] = artifact.sha256
         relative_path = f"{GROUP_PATH}/{filename}"
+
+        labels = {"vendor": "redhat"}
+        base = filename.split(".md5")[0].split(".sha1")[0].split(".sha256")[0]
+        if base.endswith(".jar"):
+            labels["type"] = "jar"
+        elif base.endswith(".pom"):
+            labels["type"] = "pom"
+        elif "cyclonedx" in base:
+            labels["type"] = "sbom"
+        elif "provenance" in base:
+            labels["type"] = "provenance"
+        elif "vex" in base:
+            labels["type"] = "vex"
+
         content = maven_artifact_api_client.create(
             artifact=artifact.pulp_href,
             relative_path=relative_path,
             repository=repo.pulp_href,
+            pulp_labels=labels,
         )
         assert content.pulp_href is not None
         content = maven_artifact_api_client.read(content.pulp_href)
@@ -67,6 +82,8 @@ def test_create_maven_artifacts(
         assert content.artifact_id == EXPECTED_ARTIFACT_ID
         assert content.version == EXPECTED_VERSION
         assert content.filename == filename
+        assert content.pulp_labels["vendor"] == "redhat"
+        assert content.pulp_labels["type"] in ("jar", "pom", "sbom", "provenance", "vex")
 
     for filename, expected_sha256 in artifact_data.items():
         unit_url = urljoin(base_url, f"{GROUP_PATH}/{filename}")
@@ -74,6 +91,28 @@ def test_create_maven_artifacts(
         assert downloaded.response_obj.status == 200
         actual_sha256 = hashlib.sha256(downloaded.body).hexdigest()
         assert actual_sha256 == expected_sha256
+
+    # Filter by single label (AND with one term)
+    results = maven_artifact_api_client.list(pulp_label_select="vendor=redhat")
+    assert results.count == 20
+
+    # Filter by AND: vendor=redhat AND type=jar (jar + its checksum files)
+    results = maven_artifact_api_client.list(pulp_label_select="vendor=redhat,type=jar")
+    assert results.count == 4  # .jar, .jar.md5, .jar.sha1, .jar.sha256
+
+    # Filter by label key existence
+    results = maven_artifact_api_client.list(pulp_label_select="type")
+    assert results.count == 20
+
+    # Filter by contains
+    results = maven_artifact_api_client.list(pulp_label_select="type~sb")
+    assert results.count == 4  # cyclonedx.json + its checksum files
+
+    # Filter by OR using q filter: type=jar OR type=pom
+    results = maven_artifact_api_client.list(
+        q='pulp_label_select="type=jar" OR pulp_label_select="type=pom"'
+    )
+    assert results.count == 8  # 4 jar files + 4 pom files
 
 
 @pytest.mark.parallel


### PR DESCRIPTION
## Summary
- Handle `pulp_labels` JSON deserialization for multipart form data uploads (the `file` field causes multipart encoding, which sends `pulp_labels` as a string)
- Add tests for label assignment at upload time
- Add label filtering tests: AND (`pulp_label_select`), key existence, contains, and OR (via `q` filter)

## Test plan
- [x] `test_create_maven_artifacts` — uploads 20 artifacts with labels, verifies labels are stored, tests filtering by single label, AND, key existence, contains, and OR via q filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)