### PR TITLE
Auto-add pull-through cached content to repository

### DIFF
--- a/CHANGES/344.feature
+++ b/CHANGES/344.feature
@@ -1,0 +1,2 @@
+Pull-through cached content is now automatically added to the repository when streamed from a
+remote, aligning with the behavior of other Pulp plugins (Python, RPM).

--- a/docs/user/guides/create-cache.md
+++ b/docs/user/guides/create-cache.md
@@ -2,6 +2,11 @@
 
 Pulp Maven can be used to cache packages from Maven Central or any other repository on the internet.
 
+When a client requests content from a distribution with a remote configured, Pulp streams the
+content from the remote and automatically saves it into the associated repository. This means
+cached content is immediately available and protected from orphan cleanup without any additional
+steps.
+
 The commands below use the `pulp-cli-maven` package available on PyPI.
 
 ## 1. Create a new Maven Remote
@@ -62,7 +67,8 @@ The commands below use the `pulp-cli-maven` package available on PyPI.
 
 ## 2. Create a Maven Repository
 
-The repository will be used to store content initially cached by pulpcore-content.
+The repository will be used to store cached content. When content is fetched via pull-through
+caching, it is automatically added to this repository.
 
 You don't have to specify a remote on it, but adding one now will enable you to not have to specify one each time you want to add newly cached content to a repository.
 
@@ -93,10 +99,9 @@ You don't have to specify a remote on it, but adding one now will enable you to 
 Create a distribution with a defined remote.
 
 Doing this ensures that when clients request content from that distribution, `pulpcore-content` will stream the content from the remote to the client.
-During that process the content is saved into Pulp.
+During that process the content is automatically saved into Pulp and added to the repository, creating a new repository version for each new content unit.
 
 Adding the repository to the distribution will enable users to browse the HTML listing pages served by `pulpcore-content`.
-However, the content will not be displayed there until the cached content is added to the repository as described in the next steps.
 
 === "run"
 
@@ -140,24 +145,7 @@ In your `~/.m2/settings.xml` add Pulp as a mirror of Maven Central. The URL come
 </settings>
 ```
 
-## 5. Add cached content to a repository
-
-Whenever content is initially cached by Pulp in the above scenario, it does not belong to any
-repository. Pulp considers such content an orphan after 24 hours. At that point an Orphan Cleanup
-task would remove the cached content from Pulp. Adding the cached content to a repository would
-prevent the cleanup from happening. The following command will create a new repository version
-by adding all Maven content that was created from a remote associated with the repository since
-the last repository version was created.
-
-=== "run"
-
-    ```bash
-    pulp maven repository add-cached-content --name maven-central
-    ```
-
-=== "output"
-
-    ```
-    Started background task /pulp/api/v3/tasks/2459cf00-3c67-4dd7-bff2-35acd72f584f/
-    Done.
-    ```
+Once your Maven client resolves packages through this mirror, Pulp automatically caches each
+artifact and adds it to the repository. The cached content will be available in subsequent
+requests even if the upstream repository becomes unreachable, and the remote can later be removed
+from the distribution without losing access to cached content.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -174,6 +174,7 @@ class MavenRepository(Repository):
     TYPE = "maven"
     CONTENT_TYPES = [MavenArtifact, MavenMetadata]
     REMOTE_TYPES = [MavenRemote]
+    PULL_THROUGH_SUPPORTED = True
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_maven/tests/functional/api/test_download_content.py
+++ b/pulp_maven/tests/functional/api/test_download_content.py
@@ -3,8 +3,6 @@
 import hashlib
 from urllib.parse import urljoin
 
-from aiohttp.client_exceptions import ClientResponseError
-
 from pulp_maven.tests.functional.utils import download_file
 
 
@@ -55,27 +53,49 @@ def test_download_content(
     content_response = maven_artifact_api_client.list(filename="custommatcher-1.0-javadoc.jar.sha1")
     assert content_response.count == 1
 
+    # Pull-through cached content is automatically added to the repository.
+    # The repository version should have incremented from 0 to 1.
+    repository = maven_repo_api_client.read(repository.pulp_href)
+    assert repository.latest_version_href.endswith("/versions/1/")
+
+    # Verify the content is in the repository version
+    repo_content = maven_artifact_api_client.list(repository_version=repository.latest_version_href)
+    assert repo_content.count >= 1
+
     # Remove the remote from the distribution
     monitor_task(
         maven_distro_api_client.partial_update(distribution.pulp_href, {"remote": None}).task
     )
 
-    # Assert that the maven artifact is no longer available
-    try:
-        download_file(pulp_unit_url)
-    except ClientResponseError as e:
-        assert e.status == 404
-
-    # Assert that the repository version is 0
-    assert repository.latest_version_href.endswith("/versions/0/")
-
-    # Add cached content to the repository
-    monitor_task(maven_repo_api_client.add_cached_content(repository.pulp_href, {}).task)
-
-    # Assert that the repository is at version 1
-    repository = maven_repo_api_client.read(repository.pulp_href)
-    assert repository.latest_version_href.endswith("/versions/1/")
-
-    # Assert that it is now once again available from the same distribution
+    # Content should still be available since it was automatically added to the repository
     downloaded_file = download_file(pulp_unit_url)
     assert downloaded_file.response_obj.status == 200
+
+
+def test_pullthrough_idempotent(
+    maven_distribution_factory,
+    maven_remote_factory,
+    maven_repo_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    distribution_base_url,
+):
+    """Verify that requesting the same content twice does not create duplicate repo versions."""
+    remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+    repository = maven_repo_factory(remote=remote.pulp_href)
+    distribution = maven_distribution_factory(
+        remote=remote.pulp_href, repository=repository.pulp_href
+    )
+
+    unit_path = "academy/alex/custommatcher/1.0/custommatcher-1.0-javadoc.jar.sha1"
+    pulp_unit_url = urljoin(distribution_base_url(distribution.base_url), unit_path)
+
+    # First request — content is fetched from remote and added to the repository
+    download_file(pulp_unit_url)
+    repository = maven_repo_api_client.read(repository.pulp_href)
+    first_version = repository.latest_version_href
+
+    # Second request — content already exists; no new version should be created
+    download_file(pulp_unit_url)
+    repository = maven_repo_api_client.read(repository.pulp_href)
+    assert repository.latest_version_href == first_version

--- a/pulp_maven/tests/functional/api/test_modify.py
+++ b/pulp_maven/tests/functional/api/test_modify.py
@@ -31,8 +31,7 @@ def test_modify_add_content_units(
     downloaded_file = download_file(pulp_unit_url)
     assert downloaded_file.response_obj.status == 200
 
-    # Add cached content to source repo so it has a repository version with content
-    monitor_task(maven_repo_api_client.add_cached_content(source_repo.pulp_href, {}).task)
+    # Content is automatically added to the repository via pull-through caching
     source_repo = maven_repo_api_client.read(source_repo.pulp_href)
     assert source_repo.latest_version_href.endswith("/versions/1/")
 
@@ -81,8 +80,7 @@ def test_modify_remove_all_content_units(
     downloaded_file = download_file(pulp_unit_url)
     assert downloaded_file.response_obj.status == 200
 
-    # Add cached content to repo
-    monitor_task(maven_repo_api_client.add_cached_content(repo.pulp_href, {}).task)
+    # Content is automatically added via pull-through caching
     repo = maven_repo_api_client.read(repo.pulp_href)
     assert repo.latest_version_href.endswith("/versions/1/")
 
@@ -129,8 +127,7 @@ def test_modify_multiple_content_units(
         downloaded_file = download_file(pulp_unit_url)
         assert downloaded_file.response_obj.status == 200
 
-    # Add cached content to source repo
-    monitor_task(maven_repo_api_client.add_cached_content(source_repo.pulp_href, {}).task)
+    # Content is automatically added via pull-through caching
     source_repo = maven_repo_api_client.read(source_repo.pulp_href)
 
     content = maven_artifact_api_client.list(repository_version=source_repo.latest_version_href)


### PR DESCRIPTION
Enable PULL_THROUGH_SUPPORTED on MavenRepository so that pulpcore's content handler automatically adds streamed content to the repository, removing the need for a separate add_cached_content call.
ref: https://redhat.atlassian.net/browse/PULP-1938

Fixes: https://github.com/pulp/pulp_maven/issues/344


<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
