### PR TITLE
Handle duplicate Maven artifact uploads by returning existing content

### DIFF
--- a/pulp_maven/app/serializers.py
+++ b/pulp_maven/app/serializers.py
@@ -37,6 +37,15 @@ class MavenArtifactSerializer(platform.SingleArtifactContentUploadSerializer):
     )
     filename = serializers.CharField(help_text=_("Filename of the artifact."), read_only=True)
 
+    def retrieve(self, validated_data):
+        return models.MavenArtifact.objects.filter(
+            group_id=validated_data["group_id"],
+            artifact_id=validated_data["artifact_id"],
+            version=validated_data["version"],
+            filename=validated_data["filename"],
+            pulp_domain=get_domain_pk(),
+        ).first()
+
     def create(self, validated_data):
         group_id, artifact_id, version, filename = (
             models.MavenArtifact.group_artifact_version_filename(validated_data["relative_path"])

--- a/pulp_maven/tests/functional/api/test_create_content.py
+++ b/pulp_maven/tests/functional/api/test_create_content.py
@@ -244,3 +244,29 @@ def test_async_create_maven_artifact(
     downloaded = download_file(unit_url)
     assert downloaded.response_obj.status == 200
     assert hashlib.sha256(downloaded.body).hexdigest() == artifact.sha256
+
+
+@pytest.mark.parallel
+def test_upload_duplicate_maven_artifact(
+    maven_artifact_api_client,
+    random_artifact_factory,
+):
+    """Test that uploading a duplicate Maven artifact returns the existing content unit."""
+    artifact = random_artifact_factory(size=64)
+    filename = "duplicate-test-1.0.0.jar"
+    relative_path = f"com/example/duplicate-test/1.0.0/{filename}"
+
+    first = maven_artifact_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path=relative_path,
+    )
+    assert first.pulp_href is not None
+
+    # Upload again with same relative_path but different artifact content
+    artifact2 = random_artifact_factory(size=64)
+    second = maven_artifact_api_client.upload(
+        artifact=artifact2.pulp_href,
+        relative_path=relative_path,
+    )
+
+    assert second.pulp_href == first.pulp_href


### PR DESCRIPTION
## Summary
- Implement `retrieve()` on `MavenArtifactSerializer` to look up existing content by `group_id`, `artifact_id`, `version`, `filename`, and `pulp_domain`
- Matches the pulp_rpm `PackageSerializer.retrieve()` pattern
- Prevents 500 errors when uploading an artifact with the same `relative_path` twice

## Test plan
- [x] `test_upload_duplicate_maven_artifact` — uploads an artifact, uploads again with same relative_path, asserts same `pulp_href` is returned

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)