### PR TITLE
Add MavenMetadata content API with upload endpoint

### DIFF
--- a/pulp_maven/app/serializers.py
+++ b/pulp_maven/app/serializers.py
@@ -104,6 +104,89 @@ class MavenArtifactUploadSerializer(MavenArtifactSerializer):
         ref_name = "MavenArtifactUploadSerializer"
 
 
+class MavenMetadataSerializer(platform.SingleArtifactContentUploadSerializer):
+    """
+    A Serializer for MavenMetadata.
+    """
+
+    group_id = serializers.CharField(
+        help_text=_("Group Id of the metadata's package."), read_only=True
+    )
+    artifact_id = serializers.CharField(
+        help_text=_("Artifact Id of the metadata's package."), read_only=True
+    )
+    version = serializers.CharField(
+        help_text=_("Version of the metadata's package."), read_only=True, allow_null=True
+    )
+    filename = serializers.CharField(help_text=_("Filename of the metadata."), read_only=True)
+    sha256 = serializers.CharField(help_text=_("SHA256 digest of the metadata."), read_only=True)
+
+    def retrieve(self, validated_data):
+        return models.MavenMetadata.objects.filter(
+            sha256=validated_data["sha256"],
+            pulp_domain=get_domain_pk(),
+        ).first()
+
+    def create(self, validated_data):
+        group_id, artifact_id, version, filename = (
+            models.MavenMetadata.group_artifact_version_filename(validated_data["relative_path"])
+        )
+        validated_data["group_id"] = group_id
+        validated_data["artifact_id"] = artifact_id
+        validated_data["version"] = version
+        validated_data["filename"] = filename
+        validated_data["sha256"] = validated_data["artifact"].sha256
+        return super().create(validated_data)
+
+    class Meta:
+        fields = platform.SingleArtifactContentUploadSerializer.Meta.fields + (
+            "group_id",
+            "artifact_id",
+            "version",
+            "filename",
+            "sha256",
+        )
+        model = models.MavenMetadata
+
+
+class MavenMetadataUploadSerializer(MavenMetadataSerializer):
+    """
+    Serializer for synchronous Maven Metadata uploads.
+    """
+
+    def __init__(self, *args, **kwargs):
+        if (
+            "data" in kwargs
+            and "pulp_labels" in kwargs["data"]
+            and isinstance(kwargs["data"]["pulp_labels"], str)
+        ):
+            try:
+                kwargs["data"]._mutable = True
+                kwargs["data"]["pulp_labels"] = json.loads(kwargs["data"]["pulp_labels"])
+                kwargs["data"]._mutable = False
+            except (json.JSONDecodeError, AttributeError):
+                pass
+        super().__init__(*args, **kwargs)
+
+    def validate(self, data):
+        data = super().validate(data)
+        if "file" in data:
+            file = data.pop("file")
+            try:
+                artifact = Artifact.objects.get(
+                    sha256=file.hashers["sha256"].hexdigest(), pulp_domain=get_domain_pk()
+                )
+                artifact.touch()
+            except (Artifact.DoesNotExist, DatabaseError):
+                artifact = Artifact.init_and_validate(file)
+                artifact.save()
+            data["artifact"] = artifact
+        return data
+
+    class Meta(MavenMetadataSerializer.Meta):
+        ref_name = "MavenMetadataUploadSerializer"
+
+
 class MavenRemoteSerializer(platform.RemoteSerializer):
     """
     A Serializer for MavenRemote.

--- a/pulp_maven/app/viewsets.py
+++ b/pulp_maven/app/viewsets.py
@@ -17,11 +17,19 @@ from pulpcore.plugin.viewsets import (
     SingleArtifactContentUploadViewSet,
 )
 
-from pulp_maven.app.models import MavenArtifact, MavenDistribution, MavenRemote, MavenRepository
+from pulp_maven.app.models import (
+    MavenArtifact,
+    MavenDistribution,
+    MavenMetadata,
+    MavenRemote,
+    MavenRepository,
+)
 from pulp_maven.app.serializers import (
     MavenArtifactSerializer,
     MavenArtifactUploadSerializer,
     MavenDistributionSerializer,
+    MavenMetadataSerializer,
+    MavenMetadataUploadSerializer,
     MavenRemoteSerializer,
     MavenRepositorySerializer,
     RepositoryAddCachedContentSerializer,
@@ -58,6 +66,44 @@ class MavenArtifactViewSet(SingleArtifactContentUploadViewSet):
     @action(detail=False, methods=["post"], serializer_class=MavenArtifactUploadSerializer)
     def upload(self, request):
         """Create a Maven artifact synchronously."""
+        serializer = self.get_serializer(data=request.data)
+        with transaction.atomic():
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class MavenMetadataFilter(ContentFilter):
+    """
+    FilterSet for MavenMetadata.
+    """
+
+    class Meta:
+        model = MavenMetadata
+        fields = ["group_id", "artifact_id", "version", "filename"]
+
+
+class MavenMetadataViewSet(SingleArtifactContentUploadViewSet):
+    """
+    A ViewSet for MavenMetadata.
+    """
+
+    endpoint_name = "metadata"
+    queryset = MavenMetadata.objects.all()
+    serializer_class = MavenMetadataSerializer
+    filterset_class = MavenMetadataFilter
+
+    @extend_schema(
+        description="Synchronously upload a Maven metadata file.",
+        request=MavenMetadataUploadSerializer,
+        responses={201: MavenMetadataSerializer},
+        summary="Upload a Maven metadata file synchronously.",
+    )
+    @action(detail=False, methods=["post"], serializer_class=MavenMetadataUploadSerializer)
+    def upload(self, request):
+        """Create a Maven metadata content unit synchronously."""
         serializer = self.get_serializer(data=request.data)
         with transaction.atomic():
             serializer.is_valid(raise_exception=True)

--- a/pulp_maven/tests/functional/api/test_create_content.py
+++ b/pulp_maven/tests/functional/api/test_create_content.py
@@ -270,3 +270,22 @@ def test_upload_duplicate_maven_artifact(
     )
 
     assert second.pulp_href == first.pulp_href
+
+
+@pytest.mark.parallel
+def test_upload_maven_metadata(
+    maven_metadata_api_client,
+    random_artifact_factory,
+):
+    """Test uploading maven-metadata.xml via the metadata endpoint."""
+    artifact = random_artifact_factory(size=64)
+    relative_path = "com/fasterxml/jackson/module/jackson-module-parameter-names/maven-metadata.xml"
+    content = maven_metadata_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path=relative_path,
+    )
+    assert content.group_id == "com.fasterxml.jackson.module"
+    assert content.artifact_id == "jackson-module-parameter-names"
+    assert content.version is None
+    assert content.filename == "maven-metadata.xml"
+    assert content.sha256 == artifact.sha256

--- a/pulp_maven/tests/functional/conftest.py
+++ b/pulp_maven/tests/functional/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from pulpcore.client.pulp_maven import (
     ApiClient,
     ContentArtifactApi,
+    ContentMetadataApi,
     DistributionsMavenApi,
     RemotesMavenApi,
     RepositoriesMavenApi,
@@ -22,6 +23,11 @@ def maven_client(_api_client_set, bindings_cfg):
 @pytest.fixture(scope="session")
 def maven_artifact_api_client(maven_client):
     return ContentArtifactApi(maven_client)
+
+
+@pytest.fixture(scope="session")
+def maven_metadata_api_client(maven_client):
+    return ContentMetadataApi(maven_client)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- Adds `MavenMetadataSerializer` and `MavenMetadataUploadSerializer` for metadata content
- Adds `MavenMetadataViewSet` at `content/maven/metadata/` with sync `upload` action
- Metadata files (maven-metadata.xml) have nullable `version` and a `sha256` field
- Includes `retrieve()` for duplicate handling (lookup by sha256 + domain)
- Adds functional test for uploading maven-metadata.xml with null version

## Test plan
- [x] `test_upload_maven_metadata` — uploads maven-metadata.xml, verifies version is None, sha256 matches

Fixes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)