### PR TITLE
Fix checksum files for maven-metadata.xml inheriting GAV from parent

### DIFF
--- a/CHANGES/371.bugfix
+++ b/CHANGES/371.bugfix
@@ -1,0 +1,2 @@
+Fixed checksum sidecar files for maven-metadata.xml failing XML parsing. Checksum files
+now inherit GAV fields from their parent maven-metadata.xml content unit.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -118,17 +118,35 @@ class MavenMetadata(MavenContentMixin, Content):
         """
         import defusedxml.ElementTree as ET
 
+        from pulpcore.plugin.models import ContentArtifact
+
         if path.isabs(relative_path):
             raise ValueError(_("Relative path can't start with '/'."))
 
         _, _, _, f_name = MavenMetadata.group_artifact_version_filename(relative_path)
 
-        with artifact.file.open("rb") as f:
-            tree = ET.parse(f)
-            root = tree.getroot()
-            group_id = root.findtext("groupId", "")
-            artifact_id = root.findtext("artifactId", "")
-            version = root.findtext("version")
+        if f_name == "maven-metadata.xml":
+            with artifact.file.open("rb") as f:
+                tree = ET.parse(f)
+                root = tree.getroot()
+                group_id = root.findtext("groupId", "")
+                artifact_id = root.findtext("artifactId", "")
+                version = root.findtext("version")
+        else:
+            parent_path = relative_path.rsplit(".", 1)[0]
+            parent_ca = ContentArtifact.objects.filter(
+                relative_path=parent_path,
+                content__pulp_domain=get_domain_pk(),
+            ).first()
+            if parent_ca:
+                parent = parent_ca.content.cast()
+                group_id = parent.group_id
+                artifact_id = parent.artifact_id
+                version = parent.version
+            else:
+                group_id, artifact_id, version, _ = MavenMetadata.group_artifact_version_filename(
+                    relative_path
+                )
 
         return MavenMetadata(
             group_id=group_id,

--- a/pulp_maven/app/serializers.py
+++ b/pulp_maven/app/serializers.py
@@ -129,17 +129,34 @@ class MavenMetadataSerializer(platform.SingleArtifactContentUploadSerializer):
         ).first()
 
     def create(self, validated_data):
-        artifact = validated_data["artifact"]
-        _, _, _, filename = models.MavenMetadata.group_artifact_version_filename(
-            validated_data["relative_path"]
-        )
+        from pulpcore.plugin.models import ContentArtifact
 
-        with artifact.file.open("rb") as f:
-            tree = ET.parse(f)
-            root = tree.getroot()
-            group_id = root.findtext("groupId", "")
-            artifact_id = root.findtext("artifactId", "")
-            version = root.findtext("version")
+        artifact = validated_data["artifact"]
+        relative_path = validated_data["relative_path"]
+        _, _, _, filename = models.MavenMetadata.group_artifact_version_filename(relative_path)
+
+        if filename == "maven-metadata.xml":
+            with artifact.file.open("rb") as f:
+                tree = ET.parse(f)
+                root = tree.getroot()
+                group_id = root.findtext("groupId", "")
+                artifact_id = root.findtext("artifactId", "")
+                version = root.findtext("version")
+        else:
+            parent_path = relative_path.rsplit(".", 1)[0]
+            parent_ca = ContentArtifact.objects.filter(
+                relative_path=parent_path,
+                content__pulp_domain=get_domain_pk(),
+            ).first()
+            if parent_ca:
+                parent = parent_ca.content.cast()
+                group_id = parent.group_id
+                artifact_id = parent.artifact_id
+                version = parent.version
+            else:
+                group_id, artifact_id, version, _ = (
+                    models.MavenMetadata.group_artifact_version_filename(relative_path)
+                )
 
         validated_data["group_id"] = group_id
         validated_data["artifact_id"] = artifact_id

--- a/pulp_maven/tests/functional/api/test_mvn_deploy.py
+++ b/pulp_maven/tests/functional/api/test_mvn_deploy.py
@@ -50,9 +50,9 @@ def test_mvn_deploy_workflow(
         msg = e.stdout.decode() + e.stderr.decode()
         pytest.fail(msg)
 
-    # Assert that the latest version is 8 (fewer versions after metadata XML parsing fix)
+    # Assert that the latest version is 12 (6 artifacts + 6 metadata including checksums)
     repo = maven_repo_api_client.read(repo.pulp_href)
-    assert repo.latest_version_href.endswith("/versions/8/")
+    assert repo.latest_version_href.endswith("/versions/12/")
 
     # Assert that you can get the metadata for the simple-project
     pulp_unit_url = urljoin(


### PR DESCRIPTION
## Summary
- Only parse XML for files named `maven-metadata.xml`, not for checksum sidecars (`.sha1`, `.md5`, etc.)
- Checksum files look up their parent `maven-metadata.xml` via `ContentArtifact.relative_path` and inherit its `group_id`, `artifact_id`, and `version`
- Falls back to path-based parsing if the parent isn't found
- Applied to both `MavenMetadata.init_from_artifact_and_relative_path()` (deploy API / pull-through) and `MavenMetadataSerializer.create()` (upload API)

## Test plan
- [x] `mvn deploy` test passes locally with all 12 files uploaded (6 artifacts + 6 metadata including checksums)

Fixes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)