### PR TITLE
Add repo_key_fields for automatic content deduplication in repositories

### DIFF
--- a/CHANGES/375.feature
+++ b/CHANGES/375.feature
@@ -1,0 +1,2 @@
+Added repo_key_fields to MavenArtifact and MavenMetadata so that duplicate content is
+automatically replaced when new content with the same GAV and filename is added to a repository.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -6,6 +6,7 @@ from os import path
 from django.db import models
 
 from pulpcore.plugin.models import Content, Distribution, Remote, Repository
+from pulpcore.plugin.repo_version_utils import remove_duplicates
 from pulpcore.plugin.util import get_domain_pk
 
 logger = getLogger(__name__)
@@ -46,6 +47,7 @@ class MavenArtifact(MavenContentMixin, Content):
     """
 
     TYPE = "artifact"
+    repo_key_fields = ("group_id", "artifact_id", "version", "filename")
 
     _pulp_domain = models.ForeignKey("core.Domain", default=get_domain_pk, on_delete=models.PROTECT)
     group_id = models.CharField(max_length=255, null=False)
@@ -87,6 +89,7 @@ class MavenMetadata(MavenContentMixin, Content):
     """
 
     TYPE = "metadata"
+    repo_key_fields = ("group_id", "artifact_id", "version", "filename")
 
     _pulp_domain = models.ForeignKey("core.Domain", default=get_domain_pk, on_delete=models.PROTECT)
     group_id = models.CharField(max_length=255, null=False)
@@ -182,6 +185,10 @@ class MavenRepository(Repository):
     CONTENT_TYPES = [MavenArtifact, MavenMetadata]
     REMOTE_TYPES = [MavenRemote]
     PULL_THROUGH_SUPPORTED = True
+
+    def finalize_new_version(self, new_version):
+        """Remove duplicate content when new content with same repo_key_fields is added."""
+        remove_duplicates(new_version)
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_maven/tests/functional/api/test_create_content.py
+++ b/pulp_maven/tests/functional/api/test_create_content.py
@@ -341,3 +341,53 @@ def test_upload_maven_metadata_snapshot(
     assert content.version == "2.8.11-SNAPSHOT"
     assert content.filename == "maven-metadata.xml"
     assert content.sha256 is not None
+
+
+@pytest.mark.parallel
+def test_repo_key_fields_replace_duplicate_metadata(
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    maven_repo_factory,
+    monitor_task,
+    tmp_path,
+):
+    """Test that metadata with same GAV+filename replaces old metadata in repository."""
+    repo = maven_repo_factory()
+    relative_path = "com/example/dedup-test/maven-metadata.xml"
+
+    # Upload first metadata
+    xml1 = b'<?xml version="1.0"?>\n<metadata><groupId>com.example</groupId><artifactId>dedup-test</artifactId><versioning><latest>1.0.0</latest><versions><version>1.0.0</version></versions></versioning></metadata>'
+    f1 = tmp_path / "maven-metadata-v1.xml"
+    f1.write_bytes(xml1)
+    content1 = maven_metadata_api_client.upload(file=str(f1), relative_path=relative_path)
+
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content1.pulp_href]}
+        ).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+    assert repo.latest_version_href.endswith("/versions/1/")
+
+    # Upload second metadata with same GAV+filename but different content (new version added)
+    xml2 = b'<?xml version="1.0"?>\n<metadata><groupId>com.example</groupId><artifactId>dedup-test</artifactId><versioning><latest>2.0.0</latest><versions><version>1.0.0</version><version>2.0.0</version></versions></versioning></metadata>'
+    f2 = tmp_path / "maven-metadata-v2.xml"
+    f2.write_bytes(xml2)
+    content2 = maven_metadata_api_client.upload(file=str(f2), relative_path=relative_path)
+
+    # Different sha256 → different content unit
+    assert content2.pulp_href != content1.pulp_href
+
+    # Add to repo — repo_key_fields should replace the old metadata
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content2.pulp_href]}
+        ).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+    assert repo.latest_version_href.endswith("/versions/2/")
+
+    # Verify only 1 metadata in repo (the new one replaced the old)
+    results = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert results.count == 1
+    assert results.results[0].pulp_href == content2.pulp_href


### PR DESCRIPTION
## Summary
- Add `repo_key_fields = ("group_id", "artifact_id", "version", "filename")` to both `MavenArtifact` and `MavenMetadata`
- Enables pulpcore's `remove_duplicates()` to automatically replace old content when new content with the same GAV+filename is added to a repository
- Prevents stale content from accumulating in repositories with frequent rebuilds

## Context
When Java packages are rebuilt frequently with the same GAV, the old and new content units would both exist in the repository. With `repo_key_fields`, the repository modify API and sync pipeline automatically remove old content matching the same key fields when new content is added.

This matches patterns used by other plugins (e.g., pulp_file uses `repo_key_fields = ("relative_path",)`).

## Test plan
- [x] Existing tests continue to pass (repo_key_fields is additive, doesn't break existing behavior)

Fixes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)