### PR TITLE
Return 400 for invalid XML in maven-metadata.xml uploads

### DIFF
--- a/CHANGES/379.bugfix
+++ b/CHANGES/379.bugfix
@@ -1,0 +1,2 @@
+Uploading invalid XML as maven-metadata.xml now returns a 400 Bad Request
+instead of a 500 Internal Server Error.

--- a/pulp_maven/app/maven_deploy_api.py
+++ b/pulp_maven/app/maven_deploy_api.py
@@ -145,10 +145,13 @@ class MavenApiViewSet(APIView):
         artifact = self.receive_artifact(chunk)
 
         # Create a MavenArtifact or MavenMetadata
-        if is_metadata:
-            content = MavenMetadata.init_from_artifact_and_relative_path(artifact, path)
-        else:
-            content = MavenArtifact.init_from_artifact_and_relative_path(artifact, path)
+        try:
+            if is_metadata:
+                content = MavenMetadata.init_from_artifact_and_relative_path(artifact, path)
+            else:
+                content = MavenArtifact.init_from_artifact_and_relative_path(artifact, path)
+        except ValueError as e:
+            return Response({"error": str(e)}, status=400)
         try:
             content.save()
         except IntegrityError:

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -129,12 +129,15 @@ class MavenMetadata(MavenContentMixin, Content):
         _, _, _, f_name = MavenMetadata.group_artifact_version_filename(relative_path)
 
         if f_name == "maven-metadata.xml":
-            with artifact.file.open("rb") as f:
-                tree = ET.parse(f)
-                root = tree.getroot()
-                group_id = root.findtext("groupId", "")
-                artifact_id = root.findtext("artifactId", "")
-                version = root.findtext("version")
+            try:
+                with artifact.file.open("rb") as f:
+                    tree = ET.parse(f)
+                    root = tree.getroot()
+                    group_id = root.findtext("groupId", "")
+                    artifact_id = root.findtext("artifactId", "")
+                    version = root.findtext("version")
+            except ET.ParseError:
+                raise ValueError("maven-metadata.xml could not be parsed as valid XML.")
         else:
             parent_path = relative_path.rsplit(".", 1)[0]
             parent_ca = ContentArtifact.objects.filter(

--- a/pulp_maven/app/serializers.py
+++ b/pulp_maven/app/serializers.py
@@ -136,12 +136,17 @@ class MavenMetadataSerializer(platform.SingleArtifactContentUploadSerializer):
         _, _, _, filename = models.MavenMetadata.group_artifact_version_filename(relative_path)
 
         if filename == "maven-metadata.xml":
-            with artifact.file.open("rb") as f:
-                tree = ET.parse(f)
-                root = tree.getroot()
-                group_id = root.findtext("groupId", "")
-                artifact_id = root.findtext("artifactId", "")
-                version = root.findtext("version")
+            try:
+                with artifact.file.open("rb") as f:
+                    tree = ET.parse(f)
+                    root = tree.getroot()
+                    group_id = root.findtext("groupId", "")
+                    artifact_id = root.findtext("artifactId", "")
+                    version = root.findtext("version")
+            except ET.ParseError:
+                raise serializers.ValidationError(
+                    {"relative_path": "maven-metadata.xml could not be parsed as valid XML."}
+                )
         else:
             parent_path = relative_path.rsplit(".", 1)[0]
             parent_ca = ContentArtifact.objects.filter(

--- a/pulp_maven/tests/functional/api/test_create_content.py
+++ b/pulp_maven/tests/functional/api/test_create_content.py
@@ -344,6 +344,23 @@ def test_upload_maven_metadata_snapshot(
 
 
 @pytest.mark.parallel
+def test_upload_invalid_xml_metadata(
+    maven_metadata_api_client,
+    tmp_path,
+):
+    """Test that uploading invalid XML as maven-metadata.xml returns 400, not 500."""
+    from pulpcore.client.pulp_maven import ApiException
+
+    temp_file = tmp_path / "maven-metadata.xml"
+    temp_file.write_text("not valid xml")
+
+    relative_path = "com/example/bad-xml/maven-metadata.xml"
+    with pytest.raises(ApiException) as exc_info:
+        maven_metadata_api_client.upload(file=str(temp_file), relative_path=relative_path)
+    assert exc_info.value.status == 400
+
+
+@pytest.mark.parallel
 def test_repo_key_fields_replace_duplicate_metadata(
     maven_metadata_api_client,
     maven_repo_api_client,


### PR DESCRIPTION
## Summary
- Catches `ET.ParseError` when uploading `maven-metadata.xml` files with invalid XML content
- Returns 400 Bad Request with a descriptive error message instead of 500 Internal Server Error
- Covers three code paths: serializer `create()`, model `init_from_artifact_and_relative_path()`, and deploy API `put()`

Fixes #379

## Test plan
- [x] New test `test_upload_invalid_xml_metadata` uploads invalid XML and asserts 400 response
- [ ] CI passes all existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)