### PR TITLE
Auto-generate maven-metadata.xml in finalize_new_version

### DIFF
--- a/CHANGES/374.bugfix
+++ b/CHANGES/374.bugfix
@@ -1,0 +1,1 @@
+Pull-through cache no longer saves maven-metadata.xml and its checksum sidecar files as persistent content. These files are now streamed directly from the remote so clients always get fresh metadata.

--- a/CHANGES/387.feature
+++ b/CHANGES/387.feature
@@ -1,0 +1,1 @@
+Auto-generate maven-metadata.xml and checksum files (.md5, .sha1, .sha256) in finalize_new_version when artifacts are added or removed from a repository version.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -1,4 +1,5 @@
 import re
+import threading
 from gettext import gettext as _
 from logging import getLogger
 from os import path
@@ -10,6 +11,11 @@ from pulpcore.plugin.repo_version_utils import remove_duplicates
 from pulpcore.plugin.util import get_domain_pk
 
 logger = getLogger(__name__)
+
+# Thread-local used to skip metadata generation during pull-through caching.
+# Pull-through tasks run asynchronously from the content app; any extra work in
+# finalize_new_version delays version creation and races with subsequent reads.
+_pull_through_ctx = threading.local()
 
 
 class MavenContentMixin:
@@ -229,9 +235,192 @@ class MavenRepository(Repository):
 
             publish(repository_version_pk=str(version.pk))
 
+    def pull_through_add_content(self, content_artifact):
+        """Use a task that skips metadata generation for pull-through content."""
+        from pulpcore.plugin.models import RepositoryContent
+
+        cpk = content_artifact.content_id
+        already_present = RepositoryContent.objects.filter(
+            content__pk=cpk, repository=self, version_removed__isnull=True
+        )
+        if not cpk or already_present.exists():
+            return None
+
+        from pulpcore.plugin.tasking import dispatch
+
+        from pulp_maven.app.tasks import pull_through_aadd_and_remove
+
+        body = {
+            "repository_pk": self.pk,
+            "add_content_units": [cpk],
+            "remove_content_units": [],
+        }
+        return dispatch(
+            pull_through_aadd_and_remove,
+            kwargs=body,
+            exclusive_resources=[self],
+            immediate=True,
+        )
+
+    async def async_pull_through_add_content(self, content_artifact):
+        """Use a task that skips metadata generation for pull-through content."""
+        from pulpcore.plugin.models import RepositoryContent
+
+        cpk = content_artifact.content_id
+        already_present = RepositoryContent.objects.filter(
+            content__pk=cpk, repository=self, version_removed__isnull=True
+        )
+        if not cpk or await already_present.aexists():
+            return None
+
+        from pulpcore.plugin.tasking import adispatch
+
+        from pulp_maven.app.tasks import pull_through_aadd_and_remove
+
+        body = {
+            "repository_pk": self.pk,
+            "add_content_units": [cpk],
+            "remove_content_units": [],
+        }
+        return await adispatch(
+            pull_through_aadd_and_remove,
+            kwargs=body,
+            exclusive_resources=[self],
+            immediate=True,
+        )
+
     def finalize_new_version(self, new_version):
-        """Remove duplicate content when new content with same repo_key_fields is added."""
+        """Remove duplicates and generate metadata for affected artifacts."""
         remove_duplicates(new_version)
+        if not getattr(_pull_through_ctx, "active", False):
+            self._generate_metadata(new_version)
+
+    def _generate_metadata(self, new_version):
+        """Generate maven-metadata.xml and checksums for affected (group_id, artifact_id) pairs."""
+        # Lazy imports to avoid circular dependency (tasks imports models)
+        import hashlib
+        import tempfile
+        from collections import defaultdict
+
+        from django.db import IntegrityError, transaction
+        from django.db.models import Q
+
+        from pulpcore.plugin.models import Artifact, ContentArtifact
+
+        from pulp_maven.app.tasks import _build_maven_metadata_xml
+
+        def _save_artifact(content_bytes):
+            """Write bytes to a temp file and create a Pulp Artifact via init_and_validate."""
+            with tempfile.NamedTemporaryFile() as tmp:
+                tmp.write(content_bytes)
+                tmp.flush()
+                artifact = Artifact.init_and_validate(tmp.name)
+                artifact.pulp_domain = self.pulp_domain
+                try:
+                    with transaction.atomic():
+                        artifact.save()
+                except IntegrityError:
+                    artifact = Artifact.objects.get(
+                        sha256=artifact.sha256,
+                        pulp_domain=self.pulp_domain,
+                    )
+            return artifact
+
+        affected_pairs = set()
+        for qs in (
+            MavenArtifact.objects.filter(pk__in=new_version.added()),
+            MavenArtifact.objects.filter(pk__in=new_version.removed()),
+        ):
+            for vals in qs.values("group_id", "artifact_id").distinct().iterator():
+                affected_pairs.add((vals["group_id"], vals["artifact_id"]))
+
+        if not affected_pairs:
+            return
+
+        metadata_filenames = [
+            "maven-metadata.xml",
+            "maven-metadata.xml.md5",
+            "maven-metadata.xml.sha1",
+            "maven-metadata.xml.sha256",
+        ]
+
+        pairs_q = Q()
+        for group_id, artifact_id in affected_pairs:
+            pairs_q |= Q(group_id=group_id, artifact_id=artifact_id)
+
+        stale = MavenMetadata.objects.filter(
+            pk__in=new_version.content,
+            version=None,
+            filename__in=metadata_filenames,
+        ).filter(pairs_q)
+        new_version.remove_content(stale)
+
+        versions_by_pair = defaultdict(set)
+        for row in (
+            MavenArtifact.objects.filter(pk__in=new_version.content)
+            .filter(pairs_q)
+            .values("group_id", "artifact_id", "version")
+            .distinct()
+        ):
+            versions_by_pair[(row["group_id"], row["artifact_id"])].add(row["version"])
+
+        new_metadata_pks = []
+
+        for (group_id, artifact_id), version_set in versions_by_pair.items():
+            versions = sorted(version_set)
+            if not versions:
+                continue
+
+            metadata_xml = _build_maven_metadata_xml(group_id, artifact_id, versions)
+            group_path = group_id.replace(".", "/")
+            base_path = f"{group_path}/{artifact_id}/maven-metadata.xml"
+
+            xml_artifact = _save_artifact(metadata_xml)
+
+            files_to_create = [("maven-metadata.xml", base_path, xml_artifact)]
+            for ext, algo in [(".md5", "md5"), (".sha1", "sha1"), (".sha256", "sha256")]:
+                checksum_value = getattr(xml_artifact, algo)
+                if checksum_value is None:
+                    checksum_value = hashlib.new(algo, metadata_xml).hexdigest()
+                checksum_bytes = checksum_value.encode("utf-8")
+                checksum_artifact = _save_artifact(checksum_bytes)
+                files_to_create.append(
+                    (
+                        f"maven-metadata.xml{ext}",
+                        f"{base_path}{ext}",
+                        checksum_artifact,
+                    )
+                )
+
+            for filename, relative_path, artifact in files_to_create:
+                metadata_content = MavenMetadata(
+                    group_id=group_id,
+                    artifact_id=artifact_id,
+                    version=None,
+                    filename=filename,
+                    sha256=artifact.sha256,
+                    _pulp_domain=self.pulp_domain,
+                )
+                try:
+                    with transaction.atomic():
+                        metadata_content.save()
+                except IntegrityError:
+                    metadata_content = MavenMetadata.objects.get(sha256=artifact.sha256)
+
+                try:
+                    with transaction.atomic():
+                        ContentArtifact.objects.create(
+                            artifact=artifact,
+                            content=metadata_content,
+                            relative_path=relative_path,
+                        )
+                except IntegrityError:
+                    pass
+
+                new_metadata_pks.append(metadata_content.pk)
+
+        if new_metadata_pks:
+            new_version.add_content(MavenMetadata.objects.filter(pk__in=new_metadata_pks))
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -182,10 +182,22 @@ class MavenRemote(Remote):
     def get_remote_artifact_content_type(relative_path=None):
         """
         Returns content type that is found at the relative_path.
+
+        Returns None for maven-metadata.xml and its checksum sidecar files so the
+        pull-through handler streams them from the remote without saving locally.
         """
-        pattern = r"\.(xml|xml\.sha1|xml\.md5|xml\.sha224|xml\.sha256|xml\.sha384|xml\.sha512)$"
-        if re.search(pattern, relative_path):
-            return MavenMetadata
+        if relative_path and relative_path.endswith(
+            (
+                "/maven-metadata.xml",
+                ".xml.md5",
+                ".xml.sha1",
+                ".xml.sha224",
+                ".xml.sha256",
+                ".xml.sha384",
+                ".xml.sha512",
+            )
+        ):
+            return None
         return MavenArtifact
 
     class Meta:

--- a/pulp_maven/app/tasks/__init__.py
+++ b/pulp_maven/app/tasks/__init__.py
@@ -27,6 +27,22 @@ async def aadd_and_remove(*args, **kwargs):
     return await sync_to_async(add_and_remove)(*args, **kwargs)
 
 
+def _add_and_remove_skip_metadata(*args, **kwargs):
+    """Wrapper around add_and_remove that skips metadata generation."""
+    from pulp_maven.app.models import _pull_through_ctx
+
+    _pull_through_ctx.active = True
+    try:
+        return add_and_remove(*args, **kwargs)
+    finally:
+        _pull_through_ctx.active = False
+
+
+async def pull_through_aadd_and_remove(*args, **kwargs):
+    """Async add_and_remove that skips metadata generation for pull-through content."""
+    return await sync_to_async(_add_and_remove_skip_metadata)(*args, **kwargs)
+
+
 def add_cached_content_to_repository(repository_pk=None, remote_pk=None):
     """
     Create a new repository version by adding content that was cached by pulpcore-content when

--- a/pulp_maven/tests/functional/api/test_download_content.py
+++ b/pulp_maven/tests/functional/api/test_download_content.py
@@ -99,3 +99,42 @@ def test_pullthrough_idempotent(
     download_file(pulp_unit_url)
     repository = maven_repo_api_client.read(repository.pulp_href)
     assert repository.latest_version_href == first_version
+
+
+def test_pullthrough_metadata_not_saved(
+    maven_distribution_factory,
+    maven_remote_factory,
+    maven_repo_factory,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    distribution_base_url,
+):
+    """Verify that maven-metadata.xml is streamed, not saved as content during pull-through."""
+    remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+    repository = maven_repo_factory(remote=remote.pulp_href)
+    distribution = maven_distribution_factory(
+        remote=remote.pulp_href, repository=repository.pulp_href
+    )
+
+    metadata_path = "academy/alex/custommatcher/maven-metadata.xml"
+    pulp_url = urljoin(distribution_base_url(distribution.base_url), metadata_path)
+
+    downloaded = download_file(pulp_url)
+    assert downloaded.response_obj.status == 200
+    assert b"<artifactId>" in downloaded.body
+
+    # No task is dispatched when get_remote_artifact_content_type returns None,
+    # so there is nothing async to wait for.
+
+    # maven-metadata.xml must NOT be saved as a MavenMetadata content unit
+    metadata_content = maven_metadata_api_client.list(
+        repository_version=maven_repo_api_client.read(repository.pulp_href).latest_version_href
+    )
+    for item in metadata_content.results:
+        assert item.filename != "maven-metadata.xml", (
+            "maven-metadata.xml should not be saved as content during pull-through"
+        )
+
+    # Repository version should not have been created for metadata
+    repository = maven_repo_api_client.read(repository.pulp_href)
+    assert repository.latest_version_href.endswith("/versions/0/")

--- a/pulp_maven/tests/functional/api/test_metadata_generation.py
+++ b/pulp_maven/tests/functional/api/test_metadata_generation.py
@@ -1,0 +1,397 @@
+"""Tests for automatic metadata generation in finalize_new_version."""
+
+import hashlib
+import uuid
+from urllib.parse import urljoin
+from xml.etree import ElementTree
+
+import pytest
+
+from pulp_maven.tests.functional.utils import download_file
+
+
+def _uid():
+    return uuid.uuid4().hex[:8]
+
+
+@pytest.mark.parallel
+def test_metadata_generated_on_artifact_add(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Adding artifacts auto-generates maven-metadata.xml with all versions listed."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    content_hrefs = []
+    for version in ["1.0.0", "1.5.0", "2.0.0"]:
+        artifact = random_artifact_factory(size=64)
+        content = maven_artifact_api_client.upload(
+            artifact=artifact.pulp_href,
+            relative_path=f"com/{uid}/mylib/{version}/mylib-{version}.jar",
+        )
+        content_hrefs.append(content.pulp_href)
+
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": content_hrefs}).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    metadata_filenames = sorted(m.filename for m in metadata_list.results)
+    assert "maven-metadata.xml" in metadata_filenames
+    assert "maven-metadata.xml.md5" in metadata_filenames
+    assert "maven-metadata.xml.sha1" in metadata_filenames
+    assert "maven-metadata.xml.sha256" in metadata_filenames
+
+    metadata_url = urljoin(base_url, f"com/{uid}/mylib/maven-metadata.xml")
+    downloaded = download_file(metadata_url)
+    assert downloaded.response_obj.status == 200
+
+    root = ElementTree.fromstring(downloaded.body)
+    assert root.findtext("groupId") == f"com.{uid}"
+    assert root.findtext("artifactId") == "mylib"
+
+    versioning = root.find("versioning")
+    assert versioning.findtext("latest") == "2.0.0"
+    assert versioning.findtext("release") == "2.0.0"
+    assert versioning.findtext("lastUpdated") is not None
+
+    versions = sorted(v.text for v in versioning.findall("versions/version"))
+    assert versions == ["1.0.0", "1.5.0", "2.0.0"]
+
+
+@pytest.mark.parallel
+def test_metadata_checksums_match_xml(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Checksum files (.md5, .sha1, .sha256) match the generated maven-metadata.xml."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path=f"com/{uid}/cksum-lib/1.0.0/cksum-lib-1.0.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+
+    metadata_url = urljoin(base_url, f"com/{uid}/cksum-lib/maven-metadata.xml")
+    metadata_download = download_file(metadata_url)
+    metadata_body = metadata_download.body
+
+    for ext, hash_func in [
+        (".md5", hashlib.md5),
+        (".sha1", hashlib.sha1),
+        (".sha256", hashlib.sha256),
+    ]:
+        checksum_url = urljoin(base_url, f"com/{uid}/cksum-lib/maven-metadata.xml{ext}")
+        checksum_download = download_file(checksum_url)
+        assert checksum_download.response_obj.status == 200
+        expected = hash_func(metadata_body).hexdigest()
+        assert checksum_download.body.decode().strip() == expected, (
+            f"Checksum mismatch for maven-metadata.xml{ext}"
+        )
+
+
+@pytest.mark.parallel
+def test_metadata_release_excludes_snapshots(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """<release> is set to the latest non-SNAPSHOT version."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    a1 = random_artifact_factory(size=64)
+    c1 = maven_artifact_api_client.upload(
+        artifact=a1.pulp_href,
+        relative_path=f"com/{uid}/snap-lib/1.0.0/snap-lib-1.0.0.jar",
+    )
+    a2 = random_artifact_factory(size=64)
+    c2 = maven_artifact_api_client.upload(
+        artifact=a2.pulp_href,
+        relative_path=f"com/{uid}/snap-lib/2.0.0-SNAPSHOT/snap-lib-2.0.0-SNAPSHOT.jar",
+    )
+
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href,
+            {"add_content_units": [c1.pulp_href, c2.pulp_href]},
+        ).task
+    )
+
+    metadata_url = urljoin(base_url, f"com/{uid}/snap-lib/maven-metadata.xml")
+    downloaded = download_file(metadata_url)
+    root = ElementTree.fromstring(downloaded.body)
+
+    versioning = root.find("versioning")
+    assert versioning.findtext("latest") == "2.0.0-SNAPSHOT"
+    assert versioning.findtext("release") == "1.0.0"
+
+    versions = sorted(v.text for v in versioning.findall("versions/version"))
+    assert versions == ["1.0.0", "2.0.0-SNAPSHOT"]
+
+
+@pytest.mark.parallel
+def test_metadata_multiple_groups(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Different (group_id, artifact_id) pairs get separate metadata files."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    a1 = random_artifact_factory(size=64)
+    c1 = maven_artifact_api_client.upload(
+        artifact=a1.pulp_href,
+        relative_path=f"com/{uid}/lib-a/1.0.0/lib-a-1.0.0.jar",
+    )
+    a2 = random_artifact_factory(size=64)
+    c2 = maven_artifact_api_client.upload(
+        artifact=a2.pulp_href,
+        relative_path=f"org/{uid}/lib-b/3.0.0/lib-b-3.0.0.jar",
+    )
+
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href,
+            {"add_content_units": [c1.pulp_href, c2.pulp_href]},
+        ).task
+    )
+
+    metadata_url_a = urljoin(base_url, f"com/{uid}/lib-a/maven-metadata.xml")
+    downloaded_a = download_file(metadata_url_a)
+    root_a = ElementTree.fromstring(downloaded_a.body)
+    assert root_a.findtext("groupId") == f"com.{uid}"
+    assert root_a.findtext("artifactId") == "lib-a"
+    versions_a = [v.text for v in root_a.findall(".//versions/version")]
+    assert versions_a == ["1.0.0"]
+
+    metadata_url_b = urljoin(base_url, f"org/{uid}/lib-b/maven-metadata.xml")
+    downloaded_b = download_file(metadata_url_b)
+    root_b = ElementTree.fromstring(downloaded_b.body)
+    assert root_b.findtext("groupId") == f"org.{uid}"
+    assert root_b.findtext("artifactId") == "lib-b"
+    versions_b = [v.text for v in root_b.findall(".//versions/version")]
+    assert versions_b == ["3.0.0"]
+
+
+@pytest.mark.parallel
+def test_metadata_updated_on_new_artifact(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Adding a new version in a subsequent repo version updates the metadata."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    a1 = random_artifact_factory(size=64)
+    c1 = maven_artifact_api_client.upload(
+        artifact=a1.pulp_href,
+        relative_path=f"com/{uid}/evolve/1.0.0/evolve-1.0.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": [c1.pulp_href]}).task
+    )
+
+    metadata_url = urljoin(base_url, f"com/{uid}/evolve/maven-metadata.xml")
+    downloaded = download_file(metadata_url)
+    root = ElementTree.fromstring(downloaded.body)
+    versions = [v.text for v in root.findall(".//versions/version")]
+    assert versions == ["1.0.0"]
+
+    a2 = random_artifact_factory(size=64)
+    c2 = maven_artifact_api_client.upload(
+        artifact=a2.pulp_href,
+        relative_path=f"com/{uid}/evolve/2.0.0/evolve-2.0.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": [c2.pulp_href]}).task
+    )
+
+    downloaded = download_file(metadata_url)
+    root = ElementTree.fromstring(downloaded.body)
+    versions = sorted(v.text for v in root.findall(".//versions/version"))
+    assert versions == ["1.0.0", "2.0.0"]
+    assert root.find("versioning").findtext("latest") == "2.0.0"
+
+
+@pytest.mark.parallel
+def test_metadata_updated_on_artifact_removal(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Removing a version updates the metadata to exclude it."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    content_hrefs = []
+    for version in ["1.0.0", "2.0.0", "3.0.0"]:
+        artifact = random_artifact_factory(size=64)
+        content = maven_artifact_api_client.upload(
+            artifact=artifact.pulp_href,
+            relative_path=f"com/{uid}/shrink/{version}/shrink-{version}.jar",
+        )
+        content_hrefs.append(content.pulp_href)
+
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": content_hrefs}).task
+    )
+
+    metadata_url = urljoin(base_url, f"com/{uid}/shrink/maven-metadata.xml")
+    downloaded = download_file(metadata_url)
+    root = ElementTree.fromstring(downloaded.body)
+    versions = sorted(v.text for v in root.findall(".//versions/version"))
+    assert versions == ["1.0.0", "2.0.0", "3.0.0"]
+
+    # Remove version 2.0.0
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"remove_content_units": [content_hrefs[1]]}
+        ).task
+    )
+
+    downloaded = download_file(metadata_url)
+    root = ElementTree.fromstring(downloaded.body)
+    versions = sorted(v.text for v in root.findall(".//versions/version"))
+    assert versions == ["1.0.0", "3.0.0"]
+    assert root.find("versioning").findtext("latest") == "3.0.0"
+
+
+@pytest.mark.parallel
+def test_metadata_removed_when_all_artifacts_removed(
+    maven_repo_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+):
+    """Metadata is removed when all artifact versions are removed from the repo."""
+    repo = maven_repo_factory()
+    uid = _uid()
+
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path=f"com/{uid}/gone/1.0.0/gone-1.0.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 4  # xml + 3 checksums
+
+    # Remove the artifact
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"remove_content_units": [content.pulp_href]}
+        ).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 0
+
+
+@pytest.mark.parallel
+def test_deploy_api_generates_metadata(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    distribution_base_url,
+    pulp_settings,
+):
+    """Pushing an artifact via the deploy API auto-generates metadata."""
+    import asyncio
+
+    import aiohttp
+
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    if pulp_settings.DOMAIN_ENABLED:
+        deploy_prefix = f"http://localhost/pulp/maven/default/{repo.name}"
+    else:
+        deploy_prefix = f"http://localhost/pulp/maven/{repo.name}"
+
+    jar_path = f"com/{uid}/deployed/1.0.0/deployed-1.0.0.jar"
+    jar_content = b"fake jar content for metadata gen test"
+
+    async def _put(url, data):
+        async with aiohttp.ClientSession(raise_for_status=True) as session:
+            async with session.put(url, data=data, verify_ssl=False) as resp:
+                return resp.status
+
+    status = asyncio.run(_put(f"{deploy_prefix}/{jar_path}", jar_content))
+    assert status == 201
+
+    repo = maven_repo_api_client.read(repo.pulp_href)
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 4  # xml + 3 checksums
+
+    metadata_url = urljoin(base_url, f"com/{uid}/deployed/maven-metadata.xml")
+    downloaded = download_file(metadata_url)
+    assert downloaded.response_obj.status == 200
+
+    root = ElementTree.fromstring(downloaded.body)
+    assert root.findtext("groupId") == f"com.{uid}"
+    assert root.findtext("artifactId") == "deployed"
+    versions = [v.text for v in root.findall(".//versions/version")]
+    assert versions == ["1.0.0"]


### PR DESCRIPTION
Update MavenRepository.finalize_new_version() to automatically generate maven-metadata.xml and checksum files (.md5, .sha1, .sha256) whenever artifacts are added or removed from a repository version. This eliminates the need for a separate publication step to produce up-to-date metadata.
ref: https://github.com/pulp/pulp_maven/issues/387

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
