### PR TITLE
Generate version-level maven-metadata.xml for SNAPSHOT versions

### DIFF
--- a/CHANGES/401.feature
+++ b/CHANGES/401.feature
@@ -1,0 +1,1 @@
+Generate version-level maven-metadata.xml for SNAPSHOT versions in finalize_new_version and repair_metadata.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -316,15 +316,21 @@ class MavenRepository(Repository):
         from pulp_maven.app.tasks import (
             METADATA_FILENAMES,
             _create_metadata_content,
+            _create_version_level_metadata_content,
         )
 
         affected_pairs = set()
+        affected_snapshot_triples = set()
         for qs in (
             MavenArtifact.objects.filter(pk__in=new_version.added()),
             MavenArtifact.objects.filter(pk__in=new_version.removed()),
         ):
-            for vals in qs.values("group_id", "artifact_id").distinct().iterator():
+            for vals in qs.values("group_id", "artifact_id", "version").distinct().iterator():
                 affected_pairs.add((vals["group_id"], vals["artifact_id"]))
+                if vals["version"] and vals["version"].endswith("-SNAPSHOT"):
+                    affected_snapshot_triples.add(
+                        (vals["group_id"], vals["artifact_id"], vals["version"])
+                    )
 
         if not affected_pairs:
             return
@@ -358,6 +364,34 @@ class MavenRepository(Repository):
             new_metadata_pks.extend(
                 _create_metadata_content(group_id, artifact_id, versions, self.pulp_domain)
             )
+
+        if affected_snapshot_triples:
+            triples_q = Q()
+            for group_id, artifact_id, version in affected_snapshot_triples:
+                triples_q |= Q(group_id=group_id, artifact_id=artifact_id, version=version)
+
+            stale_version = MavenMetadata.objects.filter(
+                pk__in=new_version.content,
+                filename__in=METADATA_FILENAMES,
+            ).filter(triples_q)
+            new_version.remove_content(stale_version)
+
+            for group_id, artifact_id, version in affected_snapshot_triples:
+                filenames = list(
+                    MavenArtifact.objects.filter(
+                        pk__in=new_version.content,
+                        group_id=group_id,
+                        artifact_id=artifact_id,
+                        version=version,
+                    ).values_list("filename", flat=True)
+                )
+                if not filenames:
+                    continue
+                new_metadata_pks.extend(
+                    _create_version_level_metadata_content(
+                        group_id, artifact_id, version, filenames, self.pulp_domain
+                    )
+                )
 
         if new_metadata_pks:
             new_version.add_content(MavenMetadata.objects.filter(pk__in=new_metadata_pks))

--- a/pulp_maven/app/tasks/__init__.py
+++ b/pulp_maven/app/tasks/__init__.py
@@ -205,6 +205,30 @@ def repair_metadata(repository_pk):
                     )
                 )
 
+            for (group_id, artifact_id), version_set in all_pairs.items():
+                for version in sorted(version_set):
+                    if not version.endswith("-SNAPSHOT"):
+                        continue
+                    filenames = list(
+                        MavenArtifact.objects.filter(
+                            pk__in=new_version.content,
+                            group_id=group_id,
+                            artifact_id=artifact_id,
+                            version=version,
+                        ).values_list("filename", flat=True)
+                    )
+                    if not filenames:
+                        continue
+                    new_metadata_pks.extend(
+                        _create_version_level_metadata_content(
+                            group_id,
+                            artifact_id,
+                            version,
+                            filenames,
+                            repository.pulp_domain,
+                        )
+                    )
+
             new_pks = set(new_metadata_pks)
 
             # Remove metadata for (group_id, artifact_id) pairs that no
@@ -229,6 +253,14 @@ def repair_metadata(repository_pk):
             ).exclude(pk__in=new_pks)
             new_version.remove_content(stale)
 
+            # Remove stale version-level SNAPSHOT metadata for active pairs.
+            stale_version = MavenMetadata.objects.filter(
+                pk__in=new_version.content,
+                version__endswith="-SNAPSHOT",
+                filename__in=METADATA_FILENAMES,
+            ).exclude(pk__in=new_pks)
+            new_version.remove_content(stale_version)
+
             already_present = set(
                 new_version.content.filter(pk__in=new_pks).values_list("pk", flat=True)
             )
@@ -245,16 +277,11 @@ def repair_metadata(repository_pk):
     )
 
 
-def _create_metadata_content(group_id, artifact_id, versions, pulp_domain):
-    """
-    Build maven-metadata.xml and checksum files for a single (group_id, artifact_id) pair.
+def _save_metadata_content(group_id, artifact_id, version, base_path, metadata_xml, pulp_domain):
+    """Save maven-metadata.xml and checksum files as MavenMetadata content.
 
-    Returns a list of MavenMetadata primary keys for the created content.
+    Returns a list of MavenMetadata primary keys.
     """
-    metadata_xml = _build_maven_metadata_xml(group_id, artifact_id, versions)
-    group_path = group_id.replace(".", "/")
-    base_path = f"{group_path}/{artifact_id}/maven-metadata.xml"
-
     xml_artifact = _save_artifact(metadata_xml, pulp_domain)
 
     files_to_create = [("maven-metadata.xml", base_path, xml_artifact)]
@@ -271,7 +298,7 @@ def _create_metadata_content(group_id, artifact_id, versions, pulp_domain):
         metadata_content = MavenMetadata(
             group_id=group_id,
             artifact_id=artifact_id,
-            version=None,
+            version=version,
             filename=filename,
             sha256=artifact.sha256,
             _pulp_domain=pulp_domain,
@@ -283,7 +310,7 @@ def _create_metadata_content(group_id, artifact_id, versions, pulp_domain):
             metadata_content = MavenMetadata.objects.get(
                 group_id=group_id,
                 artifact_id=artifact_id,
-                version=None,
+                version=version,
                 filename=filename,
                 sha256=artifact.sha256,
                 _pulp_domain=pulp_domain,
@@ -302,6 +329,17 @@ def _create_metadata_content(group_id, artifact_id, versions, pulp_domain):
         pks.append(metadata_content.pk)
 
     return pks
+
+
+def _create_metadata_content(group_id, artifact_id, versions, pulp_domain):
+    """Build repo-level maven-metadata.xml and checksums for a (group_id, artifact_id) pair.
+
+    Returns a list of MavenMetadata primary keys.
+    """
+    metadata_xml = _build_maven_metadata_xml(group_id, artifact_id, versions)
+    group_path = group_id.replace(".", "/")
+    base_path = f"{group_path}/{artifact_id}/maven-metadata.xml"
+    return _save_metadata_content(group_id, artifact_id, None, base_path, metadata_xml, pulp_domain)
 
 
 def _build_maven_metadata_xml(group_id, artifact_id, versions):
@@ -327,6 +365,75 @@ def _build_maven_metadata_xml(group_id, artifact_id, versions):
         b'<?xml version="1.0" encoding="UTF-8"?>\n'
         + tostring(root, encoding="unicode").encode("utf-8")
         + b"\n"
+    )
+
+
+def _parse_extension_and_classifier(filename, artifact_id, version):
+    """Extract extension and optional classifier from a Maven filename."""
+    prefix = f"{artifact_id}-{version}"
+    if not filename.startswith(prefix):
+        ext = filename.rsplit(".", 1)[-1] if "." in filename else ""
+        return ext, None
+    remainder = filename[len(prefix) :]
+    if remainder.startswith("-"):
+        remainder = remainder[1:]
+        if "." in remainder:
+            classifier, extension = remainder.split(".", 1)
+        else:
+            classifier = remainder
+            extension = ""
+        return extension, classifier
+    elif remainder.startswith("."):
+        return remainder[1:], None
+    else:
+        ext = filename.rsplit(".", 1)[-1] if "." in filename else ""
+        return ext, None
+
+
+def _build_version_level_metadata_xml(group_id, artifact_id, version, filenames):
+    """Build a version-level maven-metadata.xml for a SNAPSHOT version."""
+    root = Element("metadata")
+    SubElement(root, "groupId").text = group_id
+    SubElement(root, "artifactId").text = artifact_id
+    SubElement(root, "version").text = version
+
+    versioning = SubElement(root, "versioning")
+
+    snapshot = SubElement(versioning, "snapshot")
+    SubElement(snapshot, "localCopy").text = "true"
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    updated = now.strftime("%Y%m%d%H%M%S")
+
+    sv_list = SubElement(versioning, "snapshotVersions")
+    for fname in sorted(filenames):
+        extension, classifier = _parse_extension_and_classifier(fname, artifact_id, version)
+        sv = SubElement(sv_list, "snapshotVersion")
+        if classifier:
+            SubElement(sv, "classifier").text = classifier
+        SubElement(sv, "extension").text = extension
+        SubElement(sv, "value").text = version
+        SubElement(sv, "updated").text = updated
+
+    SubElement(versioning, "lastUpdated").text = updated
+
+    return (
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        + tostring(root, encoding="unicode").encode("utf-8")
+        + b"\n"
+    )
+
+
+def _create_version_level_metadata_content(group_id, artifact_id, version, filenames, pulp_domain):
+    """Build version-level maven-metadata.xml and checksums for a SNAPSHOT version.
+
+    Returns a list of MavenMetadata primary keys.
+    """
+    metadata_xml = _build_version_level_metadata_xml(group_id, artifact_id, version, filenames)
+    group_path = group_id.replace(".", "/")
+    base_path = f"{group_path}/{artifact_id}/{version}/maven-metadata.xml"
+    return _save_metadata_content(
+        group_id, artifact_id, version, base_path, metadata_xml, pulp_domain
     )
 
 

--- a/pulp_maven/tests/functional/api/test_metadata_generation.py
+++ b/pulp_maven/tests/functional/api/test_metadata_generation.py
@@ -395,3 +395,246 @@ def test_deploy_api_generates_metadata(
     assert root.findtext("artifactId") == "deployed"
     versions = [v.text for v in root.findall(".//versions/version")]
     assert versions == ["1.0.0"]
+
+
+@pytest.mark.parallel
+def test_version_level_metadata_generated_for_snapshot(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Adding SNAPSHOT artifacts generates version-level maven-metadata.xml."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    a1 = random_artifact_factory(size=64)
+    c1 = maven_artifact_api_client.upload(
+        artifact=a1.pulp_href,
+        relative_path=f"com/{uid}/snaplib/1.0-SNAPSHOT/snaplib-1.0-SNAPSHOT.jar",
+    )
+    a2 = random_artifact_factory(size=64)
+    c2 = maven_artifact_api_client.upload(
+        artifact=a2.pulp_href,
+        relative_path=f"com/{uid}/snaplib/1.0-SNAPSHOT/snaplib-1.0-SNAPSHOT.pom",
+    )
+
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href,
+            {"add_content_units": [c1.pulp_href, c2.pulp_href]},
+        ).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    # 4 repo-level + 4 version-level = 8
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 8
+
+    # Check version-level metadata XML
+    ver_url = urljoin(base_url, f"com/{uid}/snaplib/1.0-SNAPSHOT/maven-metadata.xml")
+    downloaded = download_file(ver_url)
+    assert downloaded.response_obj.status == 200
+
+    root = ElementTree.fromstring(downloaded.body)
+    assert root.findtext("groupId") == f"com.{uid}"
+    assert root.findtext("artifactId") == "snaplib"
+    assert root.findtext("version") == "1.0-SNAPSHOT"
+
+    versioning = root.find("versioning")
+    assert versioning.find("snapshot").findtext("localCopy") == "true"
+    assert versioning.findtext("lastUpdated") is not None
+
+    sv_list = versioning.findall("snapshotVersions/snapshotVersion")
+    extensions = sorted(sv.findtext("extension") for sv in sv_list)
+    assert extensions == ["jar", "pom"]
+    for sv in sv_list:
+        assert sv.findtext("value") == "1.0-SNAPSHOT"
+
+
+@pytest.mark.parallel
+def test_version_level_metadata_not_generated_for_release(
+    maven_repo_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+):
+    """Non-SNAPSHOT versions do not get version-level metadata."""
+    repo = maven_repo_factory()
+    uid = _uid()
+
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path=f"com/{uid}/rellib/1.0.0/rellib-1.0.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    # Only repo-level metadata: xml + 3 checksums = 4
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 4
+
+    # All metadata should have version=None (repo-level)
+    for m in metadata_list.results:
+        assert m.version is None
+
+
+@pytest.mark.parallel
+def test_version_level_metadata_checksums_match(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Version-level checksum files match the generated maven-metadata.xml."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path=f"com/{uid}/vcksum/1.0-SNAPSHOT/vcksum-1.0-SNAPSHOT.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+
+    ver_url = urljoin(base_url, f"com/{uid}/vcksum/1.0-SNAPSHOT/maven-metadata.xml")
+    metadata_download = download_file(ver_url)
+    metadata_body = metadata_download.body
+
+    for ext, hash_func in [
+        (".md5", hashlib.md5),
+        (".sha1", hashlib.sha1),
+        (".sha256", hashlib.sha256),
+    ]:
+        checksum_url = urljoin(base_url, f"com/{uid}/vcksum/1.0-SNAPSHOT/maven-metadata.xml{ext}")
+        checksum_download = download_file(checksum_url)
+        assert checksum_download.response_obj.status == 200
+        expected = hash_func(metadata_body).hexdigest()
+        assert checksum_download.body.decode().strip() == expected
+
+
+@pytest.mark.parallel
+def test_version_level_metadata_removed_when_snapshot_removed(
+    maven_repo_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+):
+    """Version-level metadata is removed when all SNAPSHOT artifacts are removed."""
+    repo = maven_repo_factory()
+    uid = _uid()
+
+    a1 = random_artifact_factory(size=64)
+    c1 = maven_artifact_api_client.upload(
+        artifact=a1.pulp_href,
+        relative_path=f"com/{uid}/rmsnap/1.0-SNAPSHOT/rmsnap-1.0-SNAPSHOT.jar",
+    )
+    a2 = random_artifact_factory(size=64)
+    c2 = maven_artifact_api_client.upload(
+        artifact=a2.pulp_href,
+        relative_path=f"com/{uid}/rmsnap/2.0.0/rmsnap-2.0.0.jar",
+    )
+
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href,
+            {"add_content_units": [c1.pulp_href, c2.pulp_href]},
+        ).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    # 4 repo-level + 4 version-level = 8
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 8
+
+    # Remove the SNAPSHOT artifact
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"remove_content_units": [c1.pulp_href]}).task
+    )
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    # Only repo-level metadata should remain (4)
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 4
+    for m in metadata_list.results:
+        assert m.version is None
+
+
+@pytest.mark.parallel
+def test_version_level_metadata_with_classifier(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Version-level metadata includes classifier when present in the filename."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    content_hrefs = []
+    for suffix, name in [
+        ("jar", "clslib-1.0-SNAPSHOT.jar"),
+        ("pom", "clslib-1.0-SNAPSHOT.pom"),
+        ("jar", "clslib-1.0-SNAPSHOT-sources.jar"),
+    ]:
+        artifact = random_artifact_factory(size=64)
+        content = maven_artifact_api_client.upload(
+            artifact=artifact.pulp_href,
+            relative_path=f"com/{uid}/clslib/1.0-SNAPSHOT/{name}",
+        )
+        content_hrefs.append(content.pulp_href)
+
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": content_hrefs}).task
+    )
+
+    ver_url = urljoin(base_url, f"com/{uid}/clslib/1.0-SNAPSHOT/maven-metadata.xml")
+    downloaded = download_file(ver_url)
+    root = ElementTree.fromstring(downloaded.body)
+
+    sv_list = root.findall(".//snapshotVersions/snapshotVersion")
+    assert len(sv_list) == 3
+
+    entries = []
+    for sv in sv_list:
+        entry = {"extension": sv.findtext("extension")}
+        classifier = sv.findtext("classifier")
+        if classifier:
+            entry["classifier"] = classifier
+        entries.append(entry)
+
+    entries.sort(key=lambda e: (e["extension"], e.get("classifier", "")))
+    assert entries == [
+        {"extension": "jar"},
+        {"extension": "jar", "classifier": "sources"},
+        {"extension": "pom"},
+    ]

--- a/pulp_maven/tests/functional/api/test_repair_metadata.py
+++ b/pulp_maven/tests/functional/api/test_repair_metadata.py
@@ -464,6 +464,120 @@ def test_repair_metadata_removes_orphaned_version_level_metadata(
 
 
 @pytest.mark.parallel
+def test_repair_metadata_generates_version_level_metadata(
+    populated_repo,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    monitor_task,
+):
+    """repair_metadata regenerates version-level SNAPSHOT metadata."""
+    repo, base_url, uid = populated_repo([("com", "snaprepair", ["1.0.0", "2.0.0-SNAPSHOT"])])
+
+    response = maven_repo_api_client.repair_metadata(repo.pulp_href)
+    monitor_task(response.task)
+
+    repo = maven_repo_api_client.read(repo.pulp_href)
+
+    # 4 repo-level + 4 version-level = 8
+    metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
+    assert metadata_list.count == 8
+
+    ver_url = urljoin(base_url, f"com/{uid}/snaprepair/2.0.0-SNAPSHOT/maven-metadata.xml")
+    downloaded = download_file(ver_url)
+    assert downloaded.response_obj.status == 200
+
+    root = ElementTree.fromstring(downloaded.body)
+    assert root.findtext("groupId") == f"com.{uid}"
+    assert root.findtext("artifactId") == "snaprepair"
+    assert root.findtext("version") == "2.0.0-SNAPSHOT"
+
+    versioning = root.find("versioning")
+    assert versioning.find("snapshot").findtext("localCopy") == "true"
+
+    sv_list = versioning.findall("snapshotVersions/snapshotVersion")
+    assert len(sv_list) == 1
+    assert sv_list[0].findtext("extension") == "jar"
+    assert sv_list[0].findtext("value") == "2.0.0-SNAPSHOT"
+
+
+@pytest.mark.parallel
+def test_repair_metadata_replaces_stale_version_level_metadata(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+    tmp_path,
+):
+    """repair_metadata replaces stale version-level SNAPSHOT metadata."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    content_hrefs = []
+    for name in ["snapstale-1.0-SNAPSHOT.jar", "snapstale-1.0-SNAPSHOT.pom"]:
+        artifact = random_artifact_factory(size=64)
+        content = maven_artifact_api_client.upload(
+            artifact=artifact.pulp_href,
+            relative_path=f"com/{uid}/snapstale/1.0-SNAPSHOT/{name}",
+        )
+        content_hrefs.append(content.pulp_href)
+
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": content_hrefs}).task
+    )
+
+    # Upload stale version-level metadata that only lists jar (missing pom)
+    stale_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f"<metadata><groupId>com.{uid}</groupId>"
+        "<artifactId>snapstale</artifactId>"
+        "<version>1.0-SNAPSHOT</version>"
+        "<versioning><snapshot><localCopy>true</localCopy></snapshot>"
+        "<snapshotVersions>"
+        "<snapshotVersion><extension>jar</extension>"
+        "<value>1.0-SNAPSHOT</value><updated>20200101000000</updated>"
+        "</snapshotVersion>"
+        "</snapshotVersions>"
+        "<lastUpdated>20200101000000</lastUpdated></versioning></metadata>\n"
+    )
+    stale_file = tmp_path / "maven-metadata.xml"
+    stale_file.write_text(stale_xml)
+
+    stale_metadata = maven_metadata_api_client.upload(
+        relative_path=f"com/{uid}/snapstale/1.0-SNAPSHOT/maven-metadata.xml",
+        file=str(stale_file),
+    )
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [stale_metadata.pulp_href]}
+        ).task
+    )
+
+    # Verify the stale metadata is served
+    ver_url = urljoin(base_url, f"com/{uid}/snapstale/1.0-SNAPSHOT/maven-metadata.xml")
+    downloaded = download_file(ver_url)
+    root = ElementTree.fromstring(downloaded.body)
+    sv_list = root.findall(".//snapshotVersions/snapshotVersion")
+    assert len(sv_list) == 1, "Should have stale metadata with only jar"
+
+    # Run repair
+    response = maven_repo_api_client.repair_metadata(repo.pulp_href)
+    monitor_task(response.task)
+
+    # Verify the repaired metadata has both jar and pom
+    downloaded = download_file(ver_url)
+    root = ElementTree.fromstring(downloaded.body)
+    sv_list = root.findall(".//snapshotVersions/snapshotVersion")
+    extensions = sorted(sv.findtext("extension") for sv in sv_list)
+    assert extensions == ["jar", "pom"]
+
+
+@pytest.mark.parallel
 def test_repair_metadata_empty_repo_noop(
     maven_repo_factory,
     maven_repo_api_client,


### PR DESCRIPTION
finalize_new_version and repair_metadata now generate version-level maven-metadata.xml (plus .md5, .sha1, .sha256 checksums) for SNAPSHOT versions, closing the gap where artifacts added via the modify API never got version-level metadata.

closes: #401
ref: https://redhat.atlassian.net/browse/PULP-2009

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
