### PR TITLE
Fix content_ids/RepositoryContent mismatch in _generate_metadata

### DIFF
--- a/CHANGES/405.bugfix
+++ b/CHANGES/405.bugfix
@@ -1,0 +1,2 @@
+Materialized stale metadata querysets before passing them to ``remove_content`` to prevent
+``content_ids``/``RepositoryContent`` mismatch on repositories with >= 65,535 content items.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -339,12 +339,17 @@ class MavenRepository(Repository):
         for group_id, artifact_id in affected_pairs:
             pairs_q |= Q(group_id=group_id, artifact_id=artifact_id)
 
-        stale = MavenMetadata.objects.filter(
-            pk__in=new_version.content,
-            version=None,
-            filename__in=METADATA_FILENAMES,
-        ).filter(pairs_q)
-        new_version.remove_content(stale)
+        stale_pks = list(
+            MavenMetadata.objects.filter(
+                pk__in=new_version.content,
+                version=None,
+                filename__in=METADATA_FILENAMES,
+            )
+            .filter(pairs_q)
+            .values_list("pk", flat=True)
+        )
+        if stale_pks:
+            new_version.remove_content(MavenMetadata.objects.filter(pk__in=stale_pks))
 
         versions_by_pair = defaultdict(set)
         for row in (
@@ -370,11 +375,16 @@ class MavenRepository(Repository):
             for group_id, artifact_id, version in affected_snapshot_triples:
                 triples_q |= Q(group_id=group_id, artifact_id=artifact_id, version=version)
 
-            stale_version = MavenMetadata.objects.filter(
-                pk__in=new_version.content,
-                filename__in=METADATA_FILENAMES,
-            ).filter(triples_q)
-            new_version.remove_content(stale_version)
+            stale_version_pks = list(
+                MavenMetadata.objects.filter(
+                    pk__in=new_version.content,
+                    filename__in=METADATA_FILENAMES,
+                )
+                .filter(triples_q)
+                .values_list("pk", flat=True)
+            )
+            if stale_version_pks:
+                new_version.remove_content(MavenMetadata.objects.filter(pk__in=stale_version_pks))
 
             for group_id, artifact_id, version in affected_snapshot_triples:
                 filenames = list(


### PR DESCRIPTION
Materialize stale metadata querysets before passing them to remove_content so the queryset does not transitively depend on content_ids, which is updated mid-operation. This prevents an AssertionError in _compute_counts on repositories with >= 65,535 content items.

Fixes #405

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
