### PR TITLE
feat: generate .meta/prefixes.txt for Maven repository versions

### DIFF
--- a/CHANGES/399.feature
+++ b/CHANGES/399.feature
@@ -1,0 +1,3 @@
+Added automatic generation of ``.meta/prefixes.txt`` for Maven repositories.
+The file lists the top-level group ID prefixes available in the repository,
+allowing Maven clients to efficiently determine which repositories to query.

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -183,19 +183,23 @@ class MavenRemote(Remote):
         """
         Returns content type that is found at the relative_path.
 
-        Returns None for maven-metadata.xml and its checksum sidecar files so the
-        pull-through handler streams them from the remote without saving locally.
+        Returns None for maven-metadata.xml, its checksum sidecar files, and
+        .meta/prefixes.txt so the pull-through handler streams them from the
+        remote without saving locally.
         """
-        if relative_path and relative_path.endswith(
-            (
-                "/maven-metadata.xml",
-                ".xml.md5",
-                ".xml.sha1",
-                ".xml.sha224",
-                ".xml.sha256",
-                ".xml.sha384",
-                ".xml.sha512",
+        if relative_path and (
+            relative_path.endswith(
+                (
+                    "/maven-metadata.xml",
+                    ".xml.md5",
+                    ".xml.sha1",
+                    ".xml.sha224",
+                    ".xml.sha256",
+                    ".xml.sha384",
+                    ".xml.sha512",
+                )
             )
+            or relative_path == ".meta/prefixes.txt"
         ):
             return None
         return MavenArtifact
@@ -293,8 +297,11 @@ class MavenRepository(Repository):
 
         from pulp_maven.app.tasks import (
             METADATA_FILENAMES,
+            PREFIXES_TXT_FILENAME,
+            _compute_prefix,
             _create_metadata_content,
             _create_version_level_metadata_content,
+            _save_prefixes_txt,
         )
 
         affected_pairs = set()
@@ -383,6 +390,59 @@ class MavenRepository(Repository):
 
         if new_metadata_pks:
             new_version.add_content(MavenMetadata.objects.filter(pk__in=new_metadata_pks))
+
+        # --- prefixes.txt generation ---
+        # Compute prefixes from the affected group_ids. If the set of
+        # prefixes in the repository changed (new prefixes appeared or an
+        # existing prefix lost all its artifacts), regenerate the file.
+
+        # Changed artifact prefixes (from removed or added artifacts)
+        affected_prefixes = {_compute_prefix(gid) for gid, _ in affected_pairs}
+
+        # Get all group_ids currently in the version (across ALL artifacts,
+        # not just the affected ones) so we can check whether the affected
+        # prefixes are truly new or truly gone.
+        all_group_ids = set(
+            MavenArtifact.objects.filter(pk__in=new_version.content)
+            .values_list("group_id", flat=True)
+            .distinct()
+        )
+        # All prefixes in the repo now
+        current_prefixes = {_compute_prefix(gid) for gid in all_group_ids}
+
+        unaffected_group_ids = set(
+            MavenArtifact.objects.filter(pk__in=new_version.content)
+            .exclude(pairs_q)
+            .values_list("group_id", flat=True)
+            .distinct()
+        )
+
+        unaffected_prefixes = {_compute_prefix(gid) for gid in unaffected_group_ids}
+
+        # affected prefixes not in unaffected prefix list? -> prefixes added
+        # affected prefixes not in current prefix list? -> prefixes removed
+        prefix_set_changed = bool(affected_prefixes - unaffected_prefixes) or bool(
+            affected_prefixes - current_prefixes
+        )
+
+        # Also check if this repository version has a prefixes.txt file.
+        # This catches the scenario where this logic runs for the first time
+        # on a repository that has never had a 'prefixes.txt' file and adds
+        # an artifact under an already existing prefix, so no file is generated.
+        old_prefixes_pks = list(
+            MavenMetadata.objects.filter(
+                pk__in=new_version.content,
+                filename=PREFIXES_TXT_FILENAME,
+            ).values_list("pk", flat=True)
+        )
+        if prefix_set_changed or not old_prefixes_pks:
+            # Remove old prefixes.txt from the version
+            if old_prefixes_pks:
+                new_version.remove_content(MavenMetadata.objects.filter(pk__in=old_prefixes_pks))
+
+            if current_prefixes:
+                prefixes_pks = _save_prefixes_txt(current_prefixes, self.pulp_domain)
+                new_version.add_content(MavenMetadata.objects.filter(pk__in=prefixes_pks))
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"

--- a/pulp_maven/app/tasks/__init__.py
+++ b/pulp_maven/app/tasks/__init__.py
@@ -32,6 +32,73 @@ METADATA_FILENAMES = [
     "maven-metadata.xml.sha1",
     "maven-metadata.xml.sha256",
 ]
+PREFIXES_TXT_FILENAME = ".meta/prefixes.txt"
+
+
+def _compute_prefix(group_id):
+    """Return the repository prefix for a Maven group ID.
+
+    The prefix is the first two slash-separated segments of the group path,
+    or the full path if the group ID has fewer than two segments.
+
+    Examples:
+        com.fasterxml.jackson.core -> /com/fasterxml
+        com.springframework.boot   -> /com/springframework
+        commons-fileupload         -> /commons-fileupload
+    """
+    group_path = group_id.replace(".", "/")
+    segments = group_path.split("/")
+    if len(segments) >= 2:
+        return f"/{segments[0]}/{segments[1]}"
+    return f"/{group_path}"
+
+
+def _save_prefixes_txt(prefixes, pulp_domain):
+    """Build .meta/prefixes.txt content, save as MavenMetadata, return list of PKs."""
+    # This magic header is a format marker. First line MUST be exactly this string.
+    # Maven clients look for this exact string to confirm the file is a valid
+    # prefixes list (not an HTML error page, etc).
+    # "2.0" is the format version from the Sonatype spec.
+    # The "##" prefix means it's treated as a comment/header by parsers, not as
+    # a prefix entry.
+    lines = ["## repository-prefixes/2.0"] + sorted(prefixes)
+    content_bytes = ("\n".join(lines) + "\n").encode("utf-8")
+
+    artifact = _save_artifact(content_bytes, pulp_domain)
+
+    metadata_content = MavenMetadata(
+        group_id="",
+        artifact_id="",
+        version=None,
+        filename=PREFIXES_TXT_FILENAME,
+        sha256=artifact.sha256,
+        _pulp_domain=pulp_domain,
+    )
+
+    try:
+        with transaction.atomic():
+            metadata_content.save()
+    except IntegrityError:
+        metadata_content = MavenMetadata.objects.get(
+            group_id="",
+            artifact_id="",
+            version=None,
+            filename=PREFIXES_TXT_FILENAME,
+            sha256=artifact.sha256,
+            _pulp_domain=pulp_domain,
+        )
+
+    try:
+        with transaction.atomic():
+            ContentArtifact.objects.create(
+                artifact=artifact,
+                content=metadata_content,
+                relative_path=PREFIXES_TXT_FILENAME,
+            )
+    except IntegrityError:
+        pass
+
+    return [metadata_content.pk]
 
 
 def _save_artifact(content_bytes, pulp_domain):
@@ -129,8 +196,12 @@ def repair_metadata(repository_pk):
         pk__in=latest_version.content,
         filename__in=METADATA_FILENAMES,
     ).exists()
+    has_prefixes_txt = MavenMetadata.objects.filter(
+        pk__in=latest_version.content,
+        filename=PREFIXES_TXT_FILENAME,
+    ).exists()
 
-    if not all_pairs and not has_metadata:
+    if not all_pairs and not has_metadata and not has_prefixes_txt:
         return
 
     from pulp_maven.app.models import _pull_through_ctx
@@ -212,6 +283,29 @@ def repair_metadata(repository_pk):
             pks_to_add = new_pks - already_present
             if pks_to_add:
                 new_version.add_content(MavenMetadata.objects.filter(pk__in=pks_to_add))
+
+            # --- prefixes.txt ---
+            # Remove any existing prefixes.txt (may be stale or orphaned)
+            stale_prefixes_pks = list(
+                MavenMetadata.objects.filter(
+                    pk__in=new_version.content,
+                    filename=PREFIXES_TXT_FILENAME,
+                ).values_list("pk", flat=True)
+            )
+            if stale_prefixes_pks:
+                new_version.remove_content(MavenMetadata.objects.filter(pk__in=stale_prefixes_pks))
+
+            # Rebuild from all group_ids in the repository.
+            all_group_ids = {gid for gid, _ in all_pairs}
+            all_prefixes = {_compute_prefix(gid) for gid in all_group_ids}
+            if all_prefixes:
+                prefixes_pks = _save_prefixes_txt(all_prefixes, repository.pulp_domain)
+                already_present = set(
+                    new_version.content.filter(pk__in=prefixes_pks).values_list("pk", flat=True)
+                )
+                pks_to_add = set(prefixes_pks) - already_present
+                if pks_to_add:
+                    new_version.add_content(MavenMetadata.objects.filter(pk__in=pks_to_add))
     finally:
         _pull_through_ctx.active = False
 

--- a/pulp_maven/tests/functional/api/test_metadata_generation.py
+++ b/pulp_maven/tests/functional/api/test_metadata_generation.py
@@ -333,7 +333,7 @@ def test_metadata_removed_when_all_artifacts_removed(
     repo = maven_repo_api_client.read(repo.pulp_href)
 
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 4  # xml + 3 checksums
+    assert metadata_list.count == 5  # xml + 3 checksums + prefixes.txt
 
     # Remove the artifact
     monitor_task(
@@ -384,7 +384,7 @@ def test_deploy_api_generates_metadata(
 
     repo = maven_repo_api_client.read(repo.pulp_href)
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 4  # xml + 3 checksums
+    assert metadata_list.count == 5  # xml + 3 checksums + prefixes.txt
 
     metadata_url = urljoin(base_url, f"com/{uid}/deployed/maven-metadata.xml")
     downloaded = download_file(metadata_url)
@@ -433,9 +433,9 @@ def test_version_level_metadata_generated_for_snapshot(
     )
     repo = maven_repo_api_client.read(repo.pulp_href)
 
-    # 4 repo-level + 4 version-level = 8
+    # 4 repo-level + 4 version-level + prefixes.txt = 9
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 8
+    assert metadata_list.count == 9
 
     # Check version-level metadata XML
     ver_url = urljoin(base_url, f"com/{uid}/snaplib/1.0-SNAPSHOT/maven-metadata.xml")
@@ -483,11 +483,11 @@ def test_version_level_metadata_not_generated_for_release(
     )
     repo = maven_repo_api_client.read(repo.pulp_href)
 
-    # Only repo-level metadata: xml + 3 checksums = 4
+    # Only repo-level metadata: xml + 3 checksums + prefixes.txt = 5
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 4
+    assert metadata_list.count == 5
 
-    # All metadata should have version=None (repo-level)
+    # All metadata should have version=None (repo-level, plus prefixes.txt)
     for m in metadata_list.results:
         assert m.version is None
 
@@ -567,9 +567,9 @@ def test_version_level_metadata_removed_when_snapshot_removed(
     )
     repo = maven_repo_api_client.read(repo.pulp_href)
 
-    # 4 repo-level + 4 version-level = 8
+    # 4 repo-level + 4 version-level + prefixes.txt = 9
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 8
+    assert metadata_list.count == 9
 
     # Remove the SNAPSHOT artifact
     monitor_task(
@@ -577,9 +577,9 @@ def test_version_level_metadata_removed_when_snapshot_removed(
     )
     repo = maven_repo_api_client.read(repo.pulp_href)
 
-    # Only repo-level metadata should remain (4)
+    # Only repo-level metadata should remain (4 + prefixes.txt)
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 4
+    assert metadata_list.count == 5
     for m in metadata_list.results:
         assert m.version is None
 

--- a/pulp_maven/tests/functional/api/test_prefixes_txt.py
+++ b/pulp_maven/tests/functional/api/test_prefixes_txt.py
@@ -1,0 +1,374 @@
+"""Tests for .meta/prefixes.txt generation"""
+
+import uuid
+from urllib.parse import urljoin
+
+import pytest
+
+from pulp_maven.tests.functional.utils import download_file
+
+PREFIXES_TXT_FILENAME = ".meta/prefixes.txt"
+
+
+def _uid():
+    # Each test generates unique group IDs using this random prefix, so
+    # parallel test runs don't interfere with each other. Without this,
+    # two tests both uploading "com/example/..." would see each other's
+    # prefixes.txt entries.
+    return uuid.uuid4().hex[:8]
+
+
+def _parse_prefixes(body):
+    """Parse prefixes.txt body bytes into (header, sorted prefix list)."""
+    text = body.decode("utf-8")
+    lines = [line for line in text.strip().split("\n") if line]
+    header = lines[0] if lines else ""
+    prefixes = sorted(lines[1:]) if len(lines) > 1 else []
+    return header, prefixes
+
+
+@pytest.mark.parallel
+def test_prefixes_txt_generates_on_artifact_add(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Adding artifacts generates .meta/prefixes.txt with correct prefixes."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    content_hrefs = []
+    # Two different prefixes: /com/{uid} and /org/{uid}
+    for group_prefix, artifact_id, version in [
+        (f"com/{uid}/sub", "lib-a", "1.0.0"),
+        (f"org/{uid}/sub", "lib-b", "2.0.0"),
+    ]:
+        artifact = random_artifact_factory(size=64)
+        content = maven_artifact_api_client.upload(
+            artifact=artifact.pulp_href,
+            relative_path=f"{group_prefix}/{artifact_id}/{version}/{artifact_id}-{version}.jar",
+        )
+        content_hrefs.append(content.pulp_href)
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": content_hrefs}).task
+    )
+
+    prefixes_url = urljoin(base_url, PREFIXES_TXT_FILENAME)
+    downloaded = download_file(prefixes_url)
+    assert downloaded.response_obj.status == 200
+
+    header, prefixes = _parse_prefixes(downloaded.body)
+    assert header == "## repository-prefixes/2.0"
+    assert f"/com/{uid}" in prefixes
+    assert f"/org/{uid}" in prefixes
+    assert len(prefixes) == 2
+
+
+@pytest.mark.parallel
+def test_prefixes_txt_updated_on_new_prefix(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Adding an artifact with a new prefix updates prefixes.txt"""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    # Add first artifact, creates initial prefixes.txt
+    a1 = random_artifact_factory(size=64)
+    c1 = maven_artifact_api_client.upload(
+        artifact=a1.pulp_href,
+        relative_path=f"com/{uid}/1.0/pulp/1.0/pulp-1.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": [c1.pulp_href]}).task
+    )
+
+    prefixes_url = urljoin(base_url, PREFIXES_TXT_FILENAME)
+    downloaded = download_file(prefixes_url)
+    header, prefixes = _parse_prefixes(downloaded.body)
+    assert header == "## repository-prefixes/2.0"
+    assert prefixes == [f"/com/{uid}"]
+
+    # Add artifact with NEW prefix
+    a2 = random_artifact_factory(size=64)
+    c2 = maven_artifact_api_client.upload(
+        artifact=a2.pulp_href,
+        relative_path=f"org/{uid}/1.0/other-pulp/1.0/other-pulp-1.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": [c2.pulp_href]}).task
+    )
+
+    downloaded = download_file(prefixes_url)
+    _, prefixes_after = _parse_prefixes(downloaded.body)
+    assert sorted(prefixes_after) == sorted([f"/com/{uid}", f"/org/{uid}"])
+
+
+@pytest.mark.parallel
+def test_prefixes_txt_updated_on_last_prefix_removed(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Removing the last artifact with a prefix updates prefixes.txt."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    content_hrefs = []
+    # Two different prefixes: /com/{uid} and /org/{uid}
+    for group_prefix, artifact_id, version in [
+        (f"com/{uid}/sub", "lib-a", "1.0.0"),
+        (f"com/{uid}/sub", "lib-c", "2.0.0"),
+        (f"org/{uid}/sub", "lib-b", "2.0.0"),
+    ]:
+        artifact = random_artifact_factory(size=64)
+        content = maven_artifact_api_client.upload(
+            artifact=artifact.pulp_href,
+            relative_path=f"{group_prefix}/{artifact_id}/{version}/{artifact_id}-{version}.jar",
+        )
+        content_hrefs.append(content.pulp_href)
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": content_hrefs}).task
+    )
+
+    prefixes_url = urljoin(base_url, PREFIXES_TXT_FILENAME)
+    downloaded = download_file(prefixes_url)
+    assert downloaded.response_obj.status == 200
+
+    header, prefixes = _parse_prefixes(downloaded.body)
+    assert header == "## repository-prefixes/2.0"
+    assert sorted(prefixes) == [f"/com/{uid}", f"/org/{uid}"]
+
+    removing = content_hrefs[2]
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"remove_content_units": [removing]}).task
+    )
+
+    downloaded = download_file(prefixes_url)
+    _, prefixes_after = _parse_prefixes(downloaded.body)
+    assert prefixes_after == [f"/com/{uid}"]
+
+
+@pytest.mark.parallel
+def test_prefixes_txt_not_regenerated_within_same_prefix(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Adding an artifact within an existing prefix does NOT regenerate prefixes.txt."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    # Add first artifact, creates initial prefixes.txt
+    a1 = random_artifact_factory(size=64)
+    c1 = maven_artifact_api_client.upload(
+        artifact=a1.pulp_href,
+        relative_path=f"com/{uid}/1.0/pulp/1.0/pulp-1.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": [c1.pulp_href]}).task
+    )
+
+    prefixes_url = urljoin(base_url, PREFIXES_TXT_FILENAME)
+    downloaded = download_file(prefixes_url)
+    assert downloaded.response_obj.status == 200
+
+    header, prefixes = _parse_prefixes(downloaded.body)
+    assert header == "## repository-prefixes/2.0"
+    assert prefixes == [f"/com/{uid}"]
+
+    # Add new artifact with the SAME prefix
+    a2 = random_artifact_factory(size=64)
+    c2 = maven_artifact_api_client.upload(
+        artifact=a2.pulp_href,
+        relative_path=f"com/{uid}/2.0/test-pulp/2.0/test-pulp-1.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": [c2.pulp_href]}).task
+    )
+
+    downloaded = download_file(prefixes_url)
+    assert downloaded.response_obj.status == 200
+
+    header, prefixes = _parse_prefixes(downloaded.body)
+    assert header == "## repository-prefixes/2.0"
+    assert prefixes == [f"/com/{uid}"]
+
+
+@pytest.mark.parallel
+def test_prefixes_txt_downloadable_from_content_app(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """The .meta/prefixes.txt file is downloadable from the content app."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path=f"com/{uid}/dltest/1.0.0/dltest-1.0.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+
+    prefixes_url = urljoin(base_url, ".meta/prefixes.txt")
+    downloaded = download_file(prefixes_url)
+    assert downloaded.response_obj.status == 200
+
+    text = downloaded.body.decode("utf-8")
+    assert text.startswith("## repository-prefixes/2.0\n")
+    assert f"/com/{uid}" in text
+
+
+@pytest.mark.parallel
+def test_prefixes_txt_removed_when_all_artifacts_removed(
+    maven_repo_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Removing all artifacts from a repository also removes prefixes.txt."""
+    repo = maven_repo_factory()
+    distro = maven_distribution_factory(repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+    uid = _uid()
+
+    content_hrefs = []
+    for group_prefix, artifact_id, version in [
+        (f"com/{uid}/sub", "lib-a", "1.0.0"),
+        (f"org/{uid}/sub", "lib-b", "2.0.0"),
+    ]:
+        artifact = random_artifact_factory(size=64)
+        content = maven_artifact_api_client.upload(
+            artifact=artifact.pulp_href,
+            relative_path=f"{group_prefix}/{artifact_id}/{version}/{artifact_id}-{version}.jar",
+        )
+        content_hrefs.append(content.pulp_href)
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"add_content_units": content_hrefs}).task
+    )
+
+    prefixes_url = urljoin(base_url, PREFIXES_TXT_FILENAME)
+    downloaded = download_file(prefixes_url)
+    assert downloaded.response_obj.status == 200
+
+    header, prefixes = _parse_prefixes(downloaded.body)
+    assert header == "## repository-prefixes/2.0"
+    assert len(prefixes) == 2
+
+    monitor_task(
+        maven_repo_api_client.modify(repo.pulp_href, {"remove_content_units": content_hrefs}).task
+    )
+
+    repo = maven_repo_api_client.read(repo.pulp_href)
+    metadata = maven_metadata_api_client.list(
+        repository_version=repo.latest_version_href,
+        filename=PREFIXES_TXT_FILENAME,
+    )
+    assert metadata.count == 0
+
+
+@pytest.mark.parallel
+def test_prefixes_txt_generated_for_existing_repo_without_prefixes(
+    maven_repo_factory,
+    maven_remote_factory,
+    maven_distribution_factory,
+    maven_artifact_api_client,
+    maven_metadata_api_client,
+    maven_repo_api_client,
+    random_artifact_factory,
+    monitor_task,
+    distribution_base_url,
+):
+    """Repos populated via pull-through (no prefixes.txt) get one on next modify.
+
+    Pull-through caching bypasses _generate_metadata, so repositories that were
+    populated before the prefixes.txt feature have artifacts but no
+    prefixes.txt.  When a new artifact is added under an already-existing
+    prefix, prefix_set_changed is False.  The fix detects the missing file and
+    generates it anyway.
+    """
+    remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+    repo = maven_repo_factory(remote=remote.pulp_href)
+    distro = maven_distribution_factory(remote=remote.pulp_href, repository=repo.pulp_href)
+    base_url = distribution_base_url(distro.base_url)
+
+    # Pull an artifact through the cache — this adds MavenArtifact content
+    # without running _generate_metadata, simulating a pre-existing repo.
+    pull_through_path = "academy/alex/custommatcher/1.0/custommatcher-1.0-javadoc.jar.sha1"
+    downloaded = download_file(urljoin(base_url, pull_through_path))
+    assert downloaded.response_obj.status == 200
+
+    repo = maven_repo_api_client.read(repo.pulp_href)
+    assert repo.latest_version_href.endswith("/versions/1/")
+
+    # Confirm no prefixes.txt exists yet
+    metadata = maven_metadata_api_client.list(
+        repository_version=repo.latest_version_href,
+        filename=PREFIXES_TXT_FILENAME,
+    )
+    assert metadata.count == 0
+
+    # Add another artifact under the SAME prefix ("academy") via modify.
+    # Before the fix, prefix_set_changed was False and no prefixes.txt
+    # was generated because the old code never checked for file existence.
+    artifact = random_artifact_factory(size=64)
+    content = maven_artifact_api_client.upload(
+        artifact=artifact.pulp_href,
+        relative_path="academy/alex/other-lib/1.0.0/other-lib-1.0.0.jar",
+    )
+    monitor_task(
+        maven_repo_api_client.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+
+    # prefixes.txt should now exist with the /academy/alex prefix
+    prefixes_url = urljoin(base_url, PREFIXES_TXT_FILENAME)
+    downloaded = download_file(prefixes_url)
+    assert downloaded.response_obj.status == 200
+
+    header, prefixes = _parse_prefixes(downloaded.body)
+    assert header == "## repository-prefixes/2.0"
+    assert "/academy/alex" in prefixes

--- a/pulp_maven/tests/functional/api/test_repair_metadata.py
+++ b/pulp_maven/tests/functional/api/test_repair_metadata.py
@@ -199,7 +199,7 @@ def test_repair_metadata_creates_new_version(
     assert repo.latest_version_href != version_before
 
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 4  # xml + 3 checksums
+    assert metadata_list.count == 5  # xml + 3 checksums + prefixes.txt
 
 
 @pytest.mark.parallel
@@ -478,9 +478,9 @@ def test_repair_metadata_generates_version_level_metadata(
 
     repo = maven_repo_api_client.read(repo.pulp_href)
 
-    # 4 repo-level + 4 version-level = 8
+    # 4 repo-level + 4 version-level + prefixes.txt = 9
     metadata_list = maven_metadata_api_client.list(repository_version=repo.latest_version_href)
-    assert metadata_list.count == 8
+    assert metadata_list.count == 9
 
     ver_url = urljoin(base_url, f"com/{uid}/snaprepair/2.0.0-SNAPSHOT/maven-metadata.xml")
     downloaded = download_file(ver_url)


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->
Automatically generate a `.meta/prefixes.txt` file listing top-level group ID prefixes in Maven repositories. 

This file allows Maven clients to efficiently determine which repositories to query.

- Add `_compute_prefixes` and `save_prefixes_txt` helpers to models
- Generate prefixes.txt during `_generate_metadata` and `repair_metadata`
- Only regenerate when prefixes actually change
- Add functional tests covering prefix generation, updates, removal,
  and content app download

    Closes: https://github.com/pulp/pulp_maven/issues/399
### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
