### PR TITLE
feat: add maven REST endpoints

### DIFF
--- a/CHANGES/400.feature
+++ b/CHANGES/400.feature
@@ -1,0 +1,5 @@
+Added Simple Index and JSON Metadata API endpoints for Maven repositories.
+The Simple Index (``/simple/``) lists all ``group_id:artifact_id`` projects in a
+repository, supporting HTML and JSON content negotiation. The Metadata endpoint
+(``/maven/<package>/json/``) returns detailed artifact metadata including releases
+and download URLs.

--- a/pulp_maven/app/__init__.py
+++ b/pulp_maven/app/__init__.py
@@ -42,7 +42,11 @@ def _populate_maven_access_policies(sender, apps, verbosity, **kwargs):
             )
             if created:
                 if verbosity >= 1:
-                    print(f"Access policy for {viewset_name} created.")
+                    print(
+                        "Access policy for {viewset_name} created.".format(
+                            viewset_name=viewset_name
+                        )
+                    )
             elif not db_access_policy.customized:
                 dirty = False
                 for key in ["statements", "creation_hooks", "queryset_scoping"]:
@@ -53,4 +57,8 @@ def _populate_maven_access_policies(sender, apps, verbosity, **kwargs):
                 if dirty:
                     db_access_policy.save()
                     if verbosity >= 1:
-                        print(f"Access policy for {viewset_name} updated.")
+                        print(
+                            "Access policy for {viewset_name} updated.".format(
+                                viewset_name=viewset_name
+                            )
+                        )

--- a/pulp_maven/app/__init__.py
+++ b/pulp_maven/app/__init__.py
@@ -1,3 +1,7 @@
+from gettext import gettext as _
+
+from django.db.models.signals import post_migrate
+
 from pulpcore.plugin import PulpPluginAppConfig
 
 
@@ -9,3 +13,44 @@ class PulpMavenPluginAppConfig(PulpPluginAppConfig):
     version = "0.24.0.dev"
     python_package_name = "pulp-maven"
     domain_compatible = True
+
+    def ready(self):
+        super().ready()
+        post_migrate.connect(
+            _populate_maven_access_policies,
+            sender=self,
+            dispatch_uid="populate_maven_access_policies_identifier",
+        )
+
+
+def _populate_maven_access_policies(sender, apps, verbosity, **kwargs):
+    from pulp_maven.app.simple.views import SimpleView
+
+    try:
+        AccessPolicy = apps.get_model("core", "AccessPolicy")
+    except LookupError:
+        if verbosity >= 1:
+            print(_("AccessPolicy model does not exist. Skipping initialization."))
+        return
+
+    for viewset in (SimpleView,):
+        access_policy = getattr(viewset, "DEFAULT_ACCESS_POLICY", None)
+        if access_policy is not None:
+            viewset_name = viewset.urlpattern()
+            db_access_policy, created = AccessPolicy.objects.get_or_create(
+                viewset_name=viewset_name, defaults=access_policy
+            )
+            if created:
+                if verbosity >= 1:
+                    print(f"Access policy for {viewset_name} created.")
+            elif not db_access_policy.customized:
+                dirty = False
+                for key in ["statements", "creation_hooks", "queryset_scoping"]:
+                    value = access_policy.get(key)
+                    if getattr(db_access_policy, key, None) != value:
+                        setattr(db_access_policy, key, value)
+                        dirty = True
+                if dirty:
+                    db_access_policy.save()
+                    if verbosity >= 1:
+                        print(f"Access policy for {viewset_name} updated.")

--- a/pulp_maven/app/__init__.py
+++ b/pulp_maven/app/__init__.py
@@ -24,7 +24,7 @@ class PulpMavenPluginAppConfig(PulpPluginAppConfig):
 
 
 def _populate_maven_access_policies(sender, apps, verbosity, **kwargs):
-    from pulp_maven.app.simple.views import SimpleView
+    from pulp_maven.app.simple.views import MetadataView, SimpleView
 
     try:
         AccessPolicy = apps.get_model("core", "AccessPolicy")
@@ -33,7 +33,7 @@ def _populate_maven_access_policies(sender, apps, verbosity, **kwargs):
             print(_("AccessPolicy model does not exist. Skipping initialization."))
         return
 
-    for viewset in (SimpleView,):
+    for viewset in (SimpleView, MetadataView):
         access_policy = getattr(viewset, "DEFAULT_ACCESS_POLICY", None)
         if access_policy is not None:
             viewset_name = viewset.urlpattern()

--- a/pulp_maven/app/global_access_conditions.py
+++ b/pulp_maven/app/global_access_conditions.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+
+def index_has_perm(request, view, action, perm="maven.view_mavendistribution"):
+    """Access Policy condition that checks if the user has the perm on the distribution."""
+    if request.user.has_perm(perm):
+        return True
+    if settings.DOMAIN_ENABLED:
+        if request.user.has_perm(perm, obj=request.pulp_domain):
+            return True
+    return request.user.has_perm(perm, obj=view.distribution)

--- a/pulp_maven/app/settings.py
+++ b/pulp_maven/app/settings.py
@@ -1,6 +1,9 @@
-"""
-Check `Plugin Writer's Guide`_ for more details.
+import socket
 
-.. _Plugin Writer's Guide:
-    http://docs.pulpproject.org/en/3.0/nightly/plugins/plugin-writer/index.html
-"""
+MAVEN_API_HOSTNAME = "https://" + socket.getfqdn()
+MAVEN_PATH_PREFIX = "/api/maven/"
+
+DRF_ACCESS_POLICY = {
+    "dynaconf_merge_unique": True,
+    "reusable_conditions": ["pulp_maven.app.global_access_conditions"],
+}

--- a/pulp_maven/app/simple/serializers.py
+++ b/pulp_maven/app/simple/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+
+class MavenPackageMetadataSerializer(serializers.Serializer):
+    """A Serializer for a Maven artifact's metadata."""
+
+    last_serial = serializers.IntegerField(help_text="Cache value for serial tracking")
+    info = serializers.JSONField(help_text="Core metadata of the artifact (group_id, artifact_id, version)")
+    releases = serializers.JSONField(help_text="All releases of the artifact grouped by version")
+    urls = serializers.JSONField(help_text="Download URLs for the latest (or requested) version")

--- a/pulp_maven/app/simple/serializers.py
+++ b/pulp_maven/app/simple/serializers.py
@@ -5,6 +5,8 @@ class MavenPackageMetadataSerializer(serializers.Serializer):
     """A Serializer for a Maven artifact's metadata."""
 
     last_serial = serializers.IntegerField(help_text="Cache value for serial tracking")
-    info = serializers.JSONField(help_text="Core metadata of the artifact (group_id, artifact_id, version)")
+    info = serializers.JSONField(
+        help_text="Core metadata of the artifact (group_id, artifact_id, version)"
+    )
     releases = serializers.JSONField(help_text="All releases of the artifact grouped by version")
     urls = serializers.JSONField(help_text="Download URLs for the latest (or requested) version")

--- a/pulp_maven/app/simple/utils.py
+++ b/pulp_maven/app/simple/utils.py
@@ -1,0 +1,35 @@
+from jinja2 import Template
+
+SIMPLE_API_VERSION = "1.1"
+SERIAL_CONSTANT = 1000000000
+
+simple_index_template = """<!DOCTYPE html>
+<html>
+  <head>
+    <title>Simple Index</title>
+    <meta name="maven:repository-version" content="{{ SIMPLE_API_VERSION }}">
+  </head>
+  <body>
+    {% for name in projects %}
+      <a href="{{ name }}/">{{ name }}</a><br/>
+    {% endfor %}
+  </body>
+</html>
+"""
+
+def write_simple_index(project_names, streamed=False):
+    simple = Template(simple_index_template)
+    context = {
+        "SIMPLE_API_VERSION": SIMPLE_API_VERSION,
+        "projects": project_names,
+    }
+    return simple.stream(**context) if streamed else simple.render(**context)
+
+
+def write_simple_index_json(project_names):
+    return {
+        "meta": {"api-version": SIMPLE_API_VERSION, "_last-serial": SERIAL_CONSTANT},
+        "projects": [{"name": name, "_last-serial": SERIAL_CONSTANT} for name in project_names],
+    }
+
+

--- a/pulp_maven/app/simple/utils.py
+++ b/pulp_maven/app/simple/utils.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+
+from django.conf import settings
 from jinja2 import Template
 
 SIMPLE_API_VERSION = "1.1"
@@ -33,3 +36,73 @@ def write_simple_index_json(project_names):
     }
 
 
+def maven_content_to_json(base_path, content_query, version=None, domain=None):
+    """Converts a QuerySet of MavenArtifact into a JSON metadata response."""
+    if version:
+        versioned = content_query.filter(version=version)
+        if not versioned.exists():
+            return None
+        latest_version = version
+        latest_content = versioned
+    else:
+        latest_version = None
+        for artifact in content_query.order_by("version").iterator():
+            latest_version = artifact.version
+        if not latest_version:
+            return None
+        latest_content = content_query.filter(version=latest_version)
+
+    first = content_query.first()
+    return {
+        "last_serial": 0,
+        "info": maven_content_to_info(first.group_id, first.artifact_id, latest_version),
+        "releases": maven_content_to_releases(content_query, base_path, domain),
+        "urls": [
+            maven_content_to_download_info(a, base_path, domain) for a in latest_content
+        ],
+    }
+
+
+def maven_content_to_info(group_id, artifact_id, version):
+    return {
+        "name": f"{group_id}:{artifact_id}",
+        "group_id": group_id,
+        "artifact_id": artifact_id,
+        "version": version,
+    }
+
+
+def maven_content_to_releases(content_query, base_path, domain=None):
+    releases = defaultdict(list)
+    for artifact in content_query.iterator():
+        releases[artifact.version].append(
+            maven_content_to_download_info(artifact, base_path, domain)
+        )
+    return releases
+
+
+def maven_content_to_download_info(artifact, base_path, domain=None):
+    ca = artifact.contentartifact_set.select_related("artifact").first()
+    sha256 = ca.artifact.sha256 if ca and ca.artifact else ""
+    size = ca.artifact.size if ca and ca.artifact else None
+
+    origin = settings.CONTENT_ORIGIN or settings.MAVEN_API_HOSTNAME or ""
+    origin = origin.strip("/")
+    prefix = settings.CONTENT_PATH_PREFIX.strip("/")
+    base_path = base_path.strip("/")
+    components = [origin, prefix, base_path, artifact.filename]
+    if domain:
+        components.insert(2, domain.name)
+    url = "/".join(components)
+
+    return {
+        "filename": artifact.filename,
+        "group_id": artifact.group_id,
+        "artifact_id": artifact.artifact_id,
+        "version": artifact.version,
+        "digests": {"sha256": sha256},
+        "size": size,
+        "upload_time": str(artifact.pulp_created),
+        "upload_time_iso_8601": str(artifact.pulp_created.isoformat()),
+        "url": url,
+    }

--- a/pulp_maven/app/simple/utils.py
+++ b/pulp_maven/app/simple/utils.py
@@ -79,7 +79,7 @@ def maven_content_to_info(group_id, artifact_id, version):
 
 def maven_content_to_releases(content_query, base_path, domain=None):
     releases = defaultdict(list)
-    for artifact in content_query.iterator():
+    for artifact in content_query:
         releases[artifact.version].append(
             maven_content_to_download_info(artifact, base_path, domain)
         )

--- a/pulp_maven/app/simple/utils.py
+++ b/pulp_maven/app/simple/utils.py
@@ -20,6 +20,7 @@ simple_index_template = """<!DOCTYPE html>
 </html>
 """
 
+
 def write_simple_index(project_names, streamed=False):
     simple = Template(simple_index_template)
     context = {
@@ -57,9 +58,7 @@ def maven_content_to_json(base_path, content_query, version=None, domain=None):
         "last_serial": 0,
         "info": maven_content_to_info(first.group_id, first.artifact_id, latest_version),
         "releases": maven_content_to_releases(content_query, base_path, domain),
-        "urls": [
-            maven_content_to_download_info(a, base_path, domain) for a in latest_content
-        ],
+        "urls": [maven_content_to_download_info(a, base_path, domain) for a in latest_content],
     }
 
 

--- a/pulp_maven/app/simple/utils.py
+++ b/pulp_maven/app/simple/utils.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
 
 from django.conf import settings
-from jinja2 import Template
+from jinja2 import Environment
 
 SIMPLE_API_VERSION = "1.1"
-SERIAL_CONSTANT = 1000000000
+MAVEN_SERIAL_CONSTANT = 1000000000
+MAVEN_LAST_SERIAL = "X-Maven-Last-Serial"
 
 simple_index_template = """<!DOCTYPE html>
 <html>
@@ -21,43 +22,48 @@ simple_index_template = """<!DOCTYPE html>
 """
 
 
+_jinja_env = Environment(autoescape=True)
+_simple_template = _jinja_env.from_string(simple_index_template)
+
+
 def write_simple_index(project_names, streamed=False):
-    simple = Template(simple_index_template)
     context = {
         "SIMPLE_API_VERSION": SIMPLE_API_VERSION,
         "projects": project_names,
     }
-    return simple.stream(**context) if streamed else simple.render(**context)
+    return _simple_template.stream(**context) if streamed else _simple_template.render(**context)
 
 
 def write_simple_index_json(project_names):
     return {
-        "meta": {"api-version": SIMPLE_API_VERSION, "_last-serial": SERIAL_CONSTANT},
-        "projects": [{"name": name, "_last-serial": SERIAL_CONSTANT} for name in project_names],
+        "meta": {"api-version": SIMPLE_API_VERSION, "_last-serial": MAVEN_SERIAL_CONSTANT},
+        "projects": [
+            {"name": name, "_last-serial": MAVEN_SERIAL_CONSTANT} for name in project_names
+        ],
     }
 
 
 def maven_content_to_json(base_path, content_query, version=None, domain=None):
     """Converts a QuerySet of MavenArtifact into a JSON metadata response."""
+    prefetched = content_query.prefetch_related("contentartifact_set__artifact")
+
     if version:
-        versioned = content_query.filter(version=version)
+        versioned = prefetched.filter(version=version)
         if not versioned.exists():
             return None
         latest_version = version
         latest_content = versioned
     else:
-        latest_version = None
-        for artifact in content_query.order_by("version").iterator():
-            latest_version = artifact.version
+        latest_version = prefetched.order_by("-version").values_list("version", flat=True).first()
         if not latest_version:
             return None
-        latest_content = content_query.filter(version=latest_version)
+        latest_content = prefetched.filter(version=latest_version)
 
-    first = content_query.first()
+    first = prefetched.first()
     return {
         "last_serial": 0,
         "info": maven_content_to_info(first.group_id, first.artifact_id, latest_version),
-        "releases": maven_content_to_releases(content_query, base_path, domain),
+        "releases": maven_content_to_releases(prefetched, base_path, domain),
         "urls": [maven_content_to_download_info(a, base_path, domain) for a in latest_content],
     }
 

--- a/pulp_maven/app/simple/views.py
+++ b/pulp_maven/app/simple/views.py
@@ -1,7 +1,10 @@
 from urllib.parse import urljoin
 
+from pathlib import PurePath
+
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+
 from django.http.response import (
     Http404,
     StreamingHttpResponse,
@@ -16,6 +19,7 @@ from pulpcore.plugin.util import get_domain
 from pulp_maven.app.models import MavenArtifact, MavenDistribution
 from pulp_maven.app.simple.utils import (
     SERIAL_CONSTANT,
+    maven_content_to_json,
     write_simple_index,
     write_simple_index_json,
 )
@@ -127,4 +131,51 @@ class SimpleView(MavenMixin, ViewSet):
             return StreamingHttpResponse(
                 index_data, content_type=media_type, headers=headers
             )
+
+
+class MetadataView(MavenMixin, ViewSet):
+    """View for the Maven JSON metadata endpoint."""
+
+    endpoint_name = "maven"
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {
+                "action": ["retrieve"],
+                "principal": "*",
+                "effect": "allow",
+            },
+        ],
+    }
+
+    def retrieve(self, request, path, meta):
+        """
+        Retrieves artifact metadata as JSON.
+        `meta` must be a path in form of `{group_id}:{artifact_id}/json/`
+        or `{group_id}:{artifact_id}/{version}/json/`
+        """
+        repo_version = self.get_repository_version(self.distribution)
+        content = self.get_content(repo_version)
+
+        meta_path = PurePath(meta)
+        package = None
+        version = None
+        if meta_path.match("*/*/json"):
+            package = meta_path.parts[0]
+            version = meta_path.parts[1]
+        elif meta_path.match("*/json"):
+            package = meta_path.parts[0]
+
+        if not package or ":" not in package:
+            return Response(status=404)
+
+        group_id, artifact_id = package.split(":", 1)
+        filtered = content.filter(group_id=group_id, artifact_id=artifact_id)
+
+        domain = get_domain() if settings.DOMAIN_ENABLED else None
+        json_body = maven_content_to_json(
+            self.distribution.base_path, filtered, version=version, domain=domain
+        )
+        if json_body:
+            return Response(data=json_body)
+        return Response(status=404)
 

--- a/pulp_maven/app/simple/views.py
+++ b/pulp_maven/app/simple/views.py
@@ -9,6 +9,7 @@ from django.http.response import (
     Http404,
     StreamingHttpResponse,
 )
+from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import NotAcceptable
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
 from rest_framework.response import Response
@@ -17,6 +18,7 @@ from rest_framework.viewsets import ViewSet
 from pulpcore.plugin.util import get_domain
 
 from pulp_maven.app.models import MavenArtifact, MavenDistribution
+from pulp_maven.app.simple.serializers import MavenPackageMetadataSerializer
 from pulp_maven.app.simple.utils import (
     SERIAL_CONSTANT,
     maven_content_to_json,
@@ -147,6 +149,11 @@ class MetadataView(MavenMixin, ViewSet):
         ],
     }
 
+    @extend_schema(
+        tags=["Maven: Metadata"],
+        responses={200: MavenPackageMetadataSerializer},
+        summary="Get artifact metadata",
+    )
     def retrieve(self, request, path, meta):
         """
         Retrieves artifact metadata as JSON.

--- a/pulp_maven/app/simple/views.py
+++ b/pulp_maven/app/simple/views.py
@@ -1,0 +1,130 @@
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.http.response import (
+    Http404,
+    StreamingHttpResponse,
+)
+from rest_framework.exceptions import NotAcceptable
+from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from pulpcore.plugin.util import get_domain
+
+from pulp_maven.app.models import MavenArtifact, MavenDistribution
+from pulp_maven.app.simple.utils import (
+    SERIAL_CONSTANT,
+    write_simple_index,
+    write_simple_index_json,
+)
+
+MAVEN_SIMPLE_V1_HTML = "application/vnd.maven.simple.v1+html"
+MAVEN_SIMPLE_V1_JSON = "application/vnd.maven.simple.v1+json"
+
+ORIGIN_HOST = settings.CONTENT_ORIGIN if settings.CONTENT_ORIGIN else settings.MAVEN_API_HOSTNAME
+BASE_CONTENT_URL = urljoin(ORIGIN_HOST, settings.CONTENT_PATH_PREFIX)
+BASE_API_URL = urljoin(settings.MAVEN_API_HOSTNAME, settings.MAVEN_PATH_PREFIX)
+
+
+class MavenSimpleHTMLRenderer(TemplateHTMLRenderer):
+    media_type = MAVEN_SIMPLE_V1_HTML
+
+
+class MavenSimpleJSONRenderer(JSONRenderer):
+    media_type = MAVEN_SIMPLE_V1_JSON
+
+
+class MavenMixin:
+    _distro = None
+
+    @property
+    def distribution(self):
+        if self._distro:
+            return self._distro
+
+        path = self.kwargs["path"]
+        distro = self.get_distribution(path)
+        self._distro = distro
+        return distro
+
+    @staticmethod
+    def get_distribution(path):
+        try:
+            return MavenDistribution.objects.select_related(
+                "repository",
+            ).get(base_path=path, pulp_domain=get_domain())
+        except ObjectDoesNotExist:
+            raise Http404(f"No MavenDistribution found for base_path {path}")
+
+    @staticmethod
+    def get_repository_version(distribution):
+        rep = distribution.repository
+        if rep:
+            return rep.latest_version()
+        raise Http404("No repository associated with this distribution")
+
+    @staticmethod
+    def get_content(repository_version):
+        return MavenArtifact.objects.filter(pk__in=repository_version.content)
+
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+        domain_name = get_domain().name
+        if settings.DOMAIN_ENABLED:
+            self.base_content_url = urljoin(BASE_CONTENT_URL, f"{domain_name}/")
+            self.base_api_url = urljoin(BASE_API_URL, f"{domain_name}/")
+        else:
+            self.base_content_url = BASE_CONTENT_URL
+            self.base_api_url = BASE_API_URL
+
+    @classmethod
+    def urlpattern(cls):
+        return f"maven/{cls.endpoint_name}"
+
+
+class SimpleView(MavenMixin, ViewSet):
+    endpoint_name = "simple"
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {
+                "action": ["list"],
+                "principal": "*",
+                "effect": "allow",
+            },
+        ],
+    }
+
+    def perform_content_negotiation(self, request, force=False):
+        try:
+            return super().perform_content_negotiation(request, force)
+        except NotAcceptable:
+            return TemplateHTMLRenderer(), TemplateHTMLRenderer.media_type
+
+    def get_renderers(self):
+        return [TemplateHTMLRenderer(), MavenSimpleHTMLRenderer(), MavenSimpleJSONRenderer()]
+
+    def list(self, request, path):
+        """Gets the simple index page listing all group_id:artifact_id projects."""
+        repo_version = self.get_repository_version(self.distribution)
+        content = self.get_content(repo_version)
+
+        projects = (
+            content.order_by("group_id", "artifact_id")
+            .values_list("group_id", "artifact_id")
+            .distinct()
+        )
+        project_names = [f"{g}:{a}" for g, a in projects.iterator()]
+
+        media_type = request.accepted_renderer.media_type
+        headers = {"X-PyPI-Last-Serial": str(SERIAL_CONSTANT)}
+
+        if media_type == MAVEN_SIMPLE_V1_JSON:
+            return Response(write_simple_index_json(project_names), headers=headers)
+        else:
+            index_data = write_simple_index(project_names, streamed=True)
+            return StreamingHttpResponse(
+                index_data, content_type=media_type, headers=headers
+            )
+

--- a/pulp_maven/app/simple/views.py
+++ b/pulp_maven/app/simple/views.py
@@ -1,10 +1,8 @@
-from urllib.parse import urljoin
-
 from pathlib import PurePath
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-
 from django.http.response import (
     Http404,
     StreamingHttpResponse,

--- a/pulp_maven/app/simple/views.py
+++ b/pulp_maven/app/simple/views.py
@@ -130,9 +130,7 @@ class SimpleView(MavenMixin, ViewSet):
             return Response(write_simple_index_json(project_names), headers=headers)
         else:
             index_data = write_simple_index(project_names, streamed=True)
-            return StreamingHttpResponse(
-                index_data, content_type=media_type, headers=headers
-            )
+            return StreamingHttpResponse(index_data, content_type=media_type, headers=headers)
 
 
 class MetadataView(MavenMixin, ViewSet):
@@ -185,4 +183,3 @@ class MetadataView(MavenMixin, ViewSet):
         if json_body:
             return Response(data=json_body)
         return Response(status=404)
-

--- a/pulp_maven/app/simple/views.py
+++ b/pulp_maven/app/simple/views.py
@@ -18,7 +18,8 @@ from pulpcore.plugin.util import get_domain
 from pulp_maven.app.models import MavenArtifact, MavenDistribution
 from pulp_maven.app.simple.serializers import MavenPackageMetadataSerializer
 from pulp_maven.app.simple.utils import (
-    SERIAL_CONSTANT,
+    MAVEN_LAST_SERIAL,
+    MAVEN_SERIAL_CONSTANT,
     maven_content_to_json,
     write_simple_index,
     write_simple_index_json,
@@ -41,6 +42,8 @@ class MavenSimpleJSONRenderer(JSONRenderer):
 
 
 class MavenMixin:
+    """Mixin to get index specific info."""
+
     _distro = None
 
     @property
@@ -55,6 +58,7 @@ class MavenMixin:
 
     @staticmethod
     def get_distribution(path):
+        """Finds the distribution associated with this base_path."""
         try:
             return MavenDistribution.objects.select_related(
                 "repository",
@@ -64,6 +68,7 @@ class MavenMixin:
 
     @staticmethod
     def get_repository_version(distribution):
+        """Finds the repository version this distribution is serving."""
         rep = distribution.repository
         if rep:
             return rep.latest_version()
@@ -71,9 +76,11 @@ class MavenMixin:
 
     @staticmethod
     def get_content(repository_version):
+        """Returns queryset of the content in this repository version."""
         return MavenArtifact.objects.filter(pk__in=repository_version.content)
 
     def initial(self, request, *args, **kwargs):
+        """Perform common initialization tasks for Maven endpoints."""
         super().initial(request, *args, **kwargs)
         domain_name = get_domain().name
         if settings.DOMAIN_ENABLED:
@@ -85,10 +92,13 @@ class MavenMixin:
 
     @classmethod
     def urlpattern(cls):
+        """Mocking NamedModelViewSet behavior to get APIs to support RBAC access polices."""
         return f"maven/{cls.endpoint_name}"
 
 
 class SimpleView(MavenMixin, ViewSet):
+    """View for the Maven simple API."""
+
     endpoint_name = "simple"
     DEFAULT_ACCESS_POLICY = {
         "statements": [
@@ -101,16 +111,23 @@ class SimpleView(MavenMixin, ViewSet):
     }
 
     def perform_content_negotiation(self, request, force=False):
+        """
+        Uses standard content negotiation, defaulting to HTML if no acceptable renderer is found.
+        """
         try:
             return super().perform_content_negotiation(request, force)
         except NotAcceptable:
             return TemplateHTMLRenderer(), TemplateHTMLRenderer.media_type
 
     def get_renderers(self):
+        """
+        Uses custom renderers for Maven Simple API endpoints.
+        """
         return [TemplateHTMLRenderer(), MavenSimpleHTMLRenderer(), MavenSimpleJSONRenderer()]
 
+    @extend_schema(summary="Get index simple page")
     def list(self, request, path):
-        """Gets the simple index page listing all group_id:artifact_id projects."""
+        """Gets the simple api page listing all group_id:artifact_id projects."""
         repo_version = self.get_repository_version(self.distribution)
         content = self.get_content(repo_version)
 
@@ -122,13 +139,14 @@ class SimpleView(MavenMixin, ViewSet):
         project_names = [f"{g}:{a}" for g, a in projects.iterator()]
 
         media_type = request.accepted_renderer.media_type
-        headers = {"X-PyPI-Last-Serial": str(SERIAL_CONSTANT)}
+        headers = {MAVEN_LAST_SERIAL: str(MAVEN_SERIAL_CONSTANT)}
 
         if media_type == MAVEN_SIMPLE_V1_JSON:
             return Response(write_simple_index_json(project_names), headers=headers)
         else:
             index_data = write_simple_index(project_names, streamed=True)
-            return StreamingHttpResponse(index_data, content_type=media_type, headers=headers)
+            kwargs = {"content_type": media_type, "headers": headers}
+            return StreamingHttpResponse(index_data, **kwargs)
 
 
 class MetadataView(MavenMixin, ViewSet):
@@ -175,9 +193,10 @@ class MetadataView(MavenMixin, ViewSet):
         filtered = content.filter(group_id=group_id, artifact_id=artifact_id)
 
         domain = get_domain() if settings.DOMAIN_ENABLED else None
+        headers = {MAVEN_LAST_SERIAL: str(MAVEN_SERIAL_CONSTANT)}
         json_body = maven_content_to_json(
             self.distribution.base_path, filtered, version=version, domain=domain
         )
         if json_body:
-            return Response(data=json_body)
+            return Response(data=json_body, headers=headers)
         return Response(status=404)

--- a/pulp_maven/app/urls.py
+++ b/pulp_maven/app/urls.py
@@ -5,23 +5,21 @@ from pulp_maven.app.maven_deploy_api import MavenApiViewSet
 from pulp_maven.app.simple.views import MetadataView, SimpleView
 
 if settings.DOMAIN_ENABLED:
-    deploy_re = r"(?P<pulp_domain>[-a-zA-Z0-9_]+)/(?P<name>[\w-]+)/(?P<path>.*)"
+    path_re = r"(?P<pulp_domain>[-a-zA-Z0-9_]+)/(?P<name>[\w-]+)/(?P<path>.*)"
     MAVEN_API_URL = "/<slug:pulp_domain>/<path:path>/"
 else:
-    deploy_re = r"(?P<name>[\w-]+)/(?P<path>.*)"
+    path_re = r"(?P<name>[\w-]+)/(?P<path>.*)"
     MAVEN_API_URL = "/<path:path>/"
+
 MAVEN_API_URL = settings.MAVEN_PATH_PREFIX.strip("/") + MAVEN_API_URL
 
 urlpatterns = [
-    # Deploy API (existing)
-    re_path(rf"^pulp/maven/{deploy_re}$", MavenApiViewSet.as_view()),
-    # Metadata API
+    re_path(rf"^pulp/maven/{path_re}$", MavenApiViewSet.as_view()),
     path(
         MAVEN_API_URL + "maven/<path:meta>/",
         MetadataView.as_view({"get": "retrieve"}),
         name="maven-metadata",
     ),
-    # Simple API
     path(
         MAVEN_API_URL + "simple/",
         SimpleView.as_view({"get": "list"}),

--- a/pulp_maven/app/urls.py
+++ b/pulp_maven/app/urls.py
@@ -5,25 +5,26 @@ from pulp_maven.app.maven_deploy_api import MavenApiViewSet
 from pulp_maven.app.simple.views import MetadataView, SimpleView
 
 if settings.DOMAIN_ENABLED:
-    path_re = r"(?P<pulp_domain>[-a-zA-Z0-9_]+)/(?P<name>[\w-]+)/(?P<path>.*)"
-    MAVEN_API_URL = settings.MAVEN_PATH_PREFIX.strip("/") + "/<slug:pulp_domain>/<path:path>/"
+    deploy_re = r"(?P<pulp_domain>[-a-zA-Z0-9_]+)/(?P<name>[\w-]+)/(?P<path>.*)"
+    MAVEN_API_URL = "/<slug:pulp_domain>/<path:path>/"
 else:
-    path_re = r"(?P<name>[\w-]+)/(?P<path>.*)"
-    MAVEN_API_URL = settings.MAVEN_PATH_PREFIX.strip("/") + "/<path:path>/"
+    deploy_re = r"(?P<name>[\w-]+)/(?P<path>.*)"
+    MAVEN_API_URL = "/<path:path>/"
+MAVEN_API_URL = settings.MAVEN_PATH_PREFIX.strip("/") + MAVEN_API_URL
 
 urlpatterns = [
     # Deploy API (existing)
-    re_path(rf"^pulp/maven/{path_re}$", MavenApiViewSet.as_view()),
-    # Simple API
-    path(
-        MAVEN_API_URL + "simple/",
-        SimpleView.as_view({"get": "list"}),
-        name="maven-simple-detail",
-    ),
+    re_path(rf"^pulp/maven/{deploy_re}$", MavenApiViewSet.as_view()),
     # Metadata API
     path(
         MAVEN_API_URL + "maven/<path:meta>/",
         MetadataView.as_view({"get": "retrieve"}),
         name="maven-metadata",
+    ),
+    # Simple API
+    path(
+        MAVEN_API_URL + "simple/",
+        SimpleView.as_view({"get": "list"}),
+        name="maven-simple-detail",
     ),
 ]

--- a/pulp_maven/app/urls.py
+++ b/pulp_maven/app/urls.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.urls import path, re_path
 
 from pulp_maven.app.maven_deploy_api import MavenApiViewSet
-from pulp_maven.app.simple.views import SimpleView
+from pulp_maven.app.simple.views import MetadataView, SimpleView
 
 if settings.DOMAIN_ENABLED:
     path_re = r"(?P<pulp_domain>[-a-zA-Z0-9_]+)/(?P<name>[\w-]+)/(?P<path>.*)"
@@ -19,5 +19,11 @@ urlpatterns = [
         MAVEN_API_URL + "simple/",
         SimpleView.as_view({"get": "list"}),
         name="maven-simple-detail",
+    ),
+    # Metadata API
+    path(
+        MAVEN_API_URL + "maven/<path:meta>/",
+        MetadataView.as_view({"get": "retrieve"}),
+        name="maven-metadata",
     ),
 ]

--- a/pulp_maven/app/urls.py
+++ b/pulp_maven/app/urls.py
@@ -1,13 +1,23 @@
 from django.conf import settings
-from django.urls import re_path
+from django.urls import path, re_path
 
 from pulp_maven.app.maven_deploy_api import MavenApiViewSet
+from pulp_maven.app.simple.views import SimpleView
 
 if settings.DOMAIN_ENABLED:
     path_re = r"(?P<pulp_domain>[-a-zA-Z0-9_]+)/(?P<name>[\w-]+)/(?P<path>.*)"
+    MAVEN_API_URL = settings.MAVEN_PATH_PREFIX.strip("/") + "/<slug:pulp_domain>/<path:path>/"
 else:
     path_re = r"(?P<name>[\w-]+)/(?P<path>.*)"
+    MAVEN_API_URL = settings.MAVEN_PATH_PREFIX.strip("/") + "/<path:path>/"
 
 urlpatterns = [
+    # Deploy API (existing)
     re_path(rf"^pulp/maven/{path_re}$", MavenApiViewSet.as_view()),
+    # Simple API
+    path(
+        MAVEN_API_URL + "simple/",
+        SimpleView.as_view({"get": "list"}),
+        name="maven-simple-detail",
+    ),
 ]

--- a/pulp_maven/tests/unit/test_simple.py
+++ b/pulp_maven/tests/unit/test_simple.py
@@ -1,0 +1,176 @@
+from datetime import datetime, timezone
+from pathlib import PurePath
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from pulp_maven.app.simple.utils import (
+    MAVEN_SERIAL_CONSTANT,
+    SIMPLE_API_VERSION,
+    maven_content_to_download_info,
+    write_simple_index,
+    write_simple_index_json,
+)
+
+
+class TestWriteSimpleIndex(TestCase):
+    def test_renders_project_names(self):
+        html = write_simple_index(["com.example:lib-a", "org.test:lib-b"])
+        self.assertIn('<a href="com.example:lib-a/">com.example:lib-a</a>', html)
+        self.assertIn('<a href="org.test:lib-b/">org.test:lib-b</a>', html)
+
+    def test_includes_api_version(self):
+        html = write_simple_index(["com.example:lib"])
+        self.assertIn(f'content="{SIMPLE_API_VERSION}"', html)
+
+    def test_empty_project_list(self):
+        html = write_simple_index([])
+        self.assertIn("<title>Simple Index</title>", html)
+        self.assertNotIn("<a ", html)
+
+    def test_xss_is_escaped(self):
+        html = write_simple_index(['<script>alert("xss")</script>'])
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+
+    def test_streamed_returns_stream(self):
+        result = write_simple_index(["com.example:lib"], streamed=True)
+        joined = "".join(result)
+        self.assertIn("com.example:lib", joined)
+
+
+class TestWriteSimpleIndexJson(TestCase):
+    def test_structure(self):
+        result = write_simple_index_json(["com.example:a", "com.example:b"])
+        self.assertEqual(result["meta"]["api-version"], SIMPLE_API_VERSION)
+        self.assertEqual(result["meta"]["_last-serial"], MAVEN_SERIAL_CONSTANT)
+        self.assertEqual(len(result["projects"]), 2)
+        self.assertEqual(result["projects"][0]["name"], "com.example:a")
+        self.assertEqual(result["projects"][1]["name"], "com.example:b")
+
+
+class _FakeSettings:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestMavenContentToDownloadInfo(TestCase):
+    def _make_artifact(self, **kwargs):
+        now = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        artifact_mock = MagicMock()
+        artifact_mock.filename = kwargs.get("filename", "my-lib-1.0.jar")
+        artifact_mock.group_id = kwargs.get("group_id", "com.example")
+        artifact_mock.artifact_id = kwargs.get("artifact_id", "my-lib")
+        artifact_mock.version = kwargs.get("version", "1.0.0")
+        artifact_mock.pulp_created = kwargs.get("pulp_created", now)
+
+        inner_artifact = MagicMock()
+        inner_artifact.sha256 = kwargs.get("sha256", "abc123")
+        inner_artifact.size = kwargs.get("size", 1024)
+
+        ca = MagicMock()
+        ca.artifact = inner_artifact
+        artifact_mock.contentartifact_set.select_related.return_value.first.return_value = ca
+
+        return artifact_mock
+
+    def _default_settings(self, **overrides):
+        defaults = {
+            "CONTENT_ORIGIN": "https://pulp.example.com",
+            "MAVEN_API_HOSTNAME": "",
+            "CONTENT_PATH_PREFIX": "/pulp/content/",
+        }
+        defaults.update(overrides)
+        return _FakeSettings(**defaults)
+
+    def test_builds_url_without_domain(self):
+        fake = self._default_settings()
+        with patch("pulp_maven.app.simple.utils.settings", fake):
+            artifact = self._make_artifact()
+            result = maven_content_to_download_info(artifact, "my-repo")
+
+        self.assertEqual(
+            result["url"], "https://pulp.example.com/pulp/content/my-repo/my-lib-1.0.jar"
+        )
+        self.assertEqual(result["filename"], "my-lib-1.0.jar")
+        self.assertEqual(result["digests"], {"sha256": "abc123"})
+        self.assertEqual(result["size"], 1024)
+        self.assertEqual(result["group_id"], "com.example")
+        self.assertEqual(result["artifact_id"], "my-lib")
+        self.assertEqual(result["version"], "1.0.0")
+
+    def test_builds_url_with_domain(self):
+        fake = self._default_settings()
+        with patch("pulp_maven.app.simple.utils.settings", fake):
+            domain = MagicMock()
+            domain.name = "acme"
+            artifact = self._make_artifact()
+            result = maven_content_to_download_info(artifact, "my-repo", domain=domain)
+
+        self.assertEqual(
+            result["url"],
+            "https://pulp.example.com/pulp/content/acme/my-repo/my-lib-1.0.jar",
+        )
+
+    def test_missing_content_artifact(self):
+        fake = self._default_settings()
+        with patch("pulp_maven.app.simple.utils.settings", fake):
+            artifact = self._make_artifact()
+            artifact.contentartifact_set.select_related.return_value.first.return_value = None
+            result = maven_content_to_download_info(artifact, "my-repo")
+
+        self.assertEqual(result["digests"], {"sha256": ""})
+        self.assertIsNone(result["size"])
+
+    def test_fallback_to_maven_api_hostname(self):
+        fake = self._default_settings(
+            CONTENT_ORIGIN="",
+            MAVEN_API_HOSTNAME="https://maven.example.com",
+            CONTENT_PATH_PREFIX="/content/",
+        )
+        with patch("pulp_maven.app.simple.utils.settings", fake):
+            artifact = self._make_artifact(filename="app.jar")
+            result = maven_content_to_download_info(artifact, "repo")
+
+        self.assertTrue(result["url"].startswith("https://maven.example.com/"))
+
+
+class TestMetadataPathParsing(TestCase):
+    """Test the path parsing logic used in MetadataView.retrieve."""
+
+    @staticmethod
+    def _parse_meta(meta):
+        meta_path = PurePath(meta)
+        package = None
+        version = None
+        if meta_path.match("*/*/json"):
+            package = meta_path.parts[0]
+            version = meta_path.parts[1]
+        elif meta_path.match("*/json"):
+            package = meta_path.parts[0]
+        return package, version
+
+    def test_package_only(self):
+        package, version = self._parse_meta("com.example:my-lib/json")
+        self.assertEqual(package, "com.example:my-lib")
+        self.assertIsNone(version)
+
+    def test_package_with_version(self):
+        package, version = self._parse_meta("com.example:my-lib/1.0.0/json")
+        self.assertEqual(package, "com.example:my-lib")
+        self.assertEqual(version, "1.0.0")
+
+    def test_trailing_slash(self):
+        package, version = self._parse_meta("com.example:my-lib/json/")
+        self.assertEqual(package, "com.example:my-lib")
+        self.assertIsNone(version)
+
+    def test_no_json_suffix(self):
+        package, version = self._parse_meta("com.example:my-lib/1.0.0")
+        self.assertIsNone(package)
+        self.assertIsNone(version)
+
+    def test_empty_string(self):
+        package, version = self._parse_meta("")
+        self.assertIsNone(package)
+        self.assertIsNone(version)


### PR DESCRIPTION
### What this PR does

- Adds 2 new REST Endpoints:
  - GET `/api/maven/{pulp_domain}/{path}/simple/`
  - GET '/api/maven/{pulp_domain}/{path}/maven/{meta}/' where `meta` must be a path in form of:
    -  `{group_id}:{artifact_id}/json/` or
    - `{group_id}:{artifact_id}/{version}/json/`

### Why the new endpoints are needed
- In order to expose packages through https://github.com/pulp/pulp-service I encountered that maven packages did not have those endpoint while the python one did have. So I needed some consistency between both python and maven
- The repository https://github.com/pulp/pulp_python contains exactly the same endpoints with exactly the same definitions and functionality.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
