### PR TITLE
Add RBAC permissions to all Maven viewsets

### DIFF
--- a/CHANGES/308.feature
+++ b/CHANGES/308.feature
@@ -1,0 +1,2 @@
+Added Role-Based Access Control (RBAC) to all Maven viewsets with granular
+permissions for repositories, remotes, distributions, and content.

--- a/pulp_maven/app/migrations/0012_add_rbac_permissions.py
+++ b/pulp_maven/app/migrations/0012_add_rbac_permissions.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("maven", "0011_backfill_mavenpackage"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="mavendistribution",
+            options={
+                "default_related_name": "%(app_label)s_%(model_name)s",
+                "permissions": [
+                    (
+                        "manage_roles_mavendistribution",
+                        "Can manage roles on Maven distribution",
+                    ),
+                ],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="mavenremote",
+            options={
+                "default_related_name": "%(app_label)s_%(model_name)s",
+                "permissions": [
+                    ("manage_roles_mavenremote", "Can manage roles on Maven remote"),
+                ],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="mavenrepository",
+            options={
+                "default_related_name": "%(app_label)s_%(model_name)s",
+                "permissions": [
+                    (
+                        "modify_mavenrepository",
+                        "Can modify content in Maven repository",
+                    ),
+                    (
+                        "manage_roles_mavenrepository",
+                        "Can manage roles on Maven repository",
+                    ),
+                    (
+                        "repair_mavenrepository",
+                        "Can repair Maven repository metadata",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/pulp_maven/app/models.py
+++ b/pulp_maven/app/models.py
@@ -6,7 +6,13 @@ from os import path
 
 from django.db import models
 
-from pulpcore.plugin.models import Content, Distribution, Remote, Repository
+from pulpcore.plugin.models import (
+    AutoAddObjPermsMixin,
+    Content,
+    Distribution,
+    Remote,
+    Repository,
+)
 from pulpcore.plugin.repo_version_utils import remove_duplicates
 from pulpcore.plugin.util import get_domain_pk
 
@@ -222,7 +228,7 @@ class MavenPackage(Content):
         self.scm_url = meta["scm_url"]
 
 
-class MavenRemote(Remote):
+class MavenRemote(Remote, AutoAddObjPermsMixin):
     """
     A Remote for MavenArtifact.
 
@@ -259,9 +265,12 @@ class MavenRemote(Remote):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+        permissions = [  # noqa: RUF012
+            ("manage_roles_mavenremote", "Can manage roles on Maven remote"),
+        ]
 
 
-class MavenDistribution(Distribution):
+class MavenDistribution(Distribution, AutoAddObjPermsMixin):
     """
     Distribution for 'maven' content.
     """
@@ -270,16 +279,19 @@ class MavenDistribution(Distribution):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+        permissions = [  # noqa: RUF012
+            ("manage_roles_mavendistribution", "Can manage roles on Maven distribution"),
+        ]
 
 
-class MavenRepository(Repository):
+class MavenRepository(Repository, AutoAddObjPermsMixin):
     """
     Repository for "maven" content.
     """
 
     TYPE = "maven"
-    CONTENT_TYPES = [MavenArtifact, MavenMetadata, MavenPackage]
-    REMOTE_TYPES = [MavenRemote]
+    CONTENT_TYPES = [MavenArtifact, MavenMetadata, MavenPackage]  # noqa: RUF012
+    REMOTE_TYPES = [MavenRemote]  # noqa: RUF012
     PULL_THROUGH_SUPPORTED = True
 
     def pull_through_add_content(self, content_artifact):
@@ -602,3 +614,8 @@ class MavenRepository(Repository):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+        permissions = [  # noqa: RUF012
+            ("modify_mavenrepository", "Can modify content in Maven repository"),
+            ("manage_roles_mavenrepository", "Can manage roles on Maven repository"),
+            ("repair_mavenrepository", "Can repair Maven repository metadata"),
+        ]

--- a/pulp_maven/app/viewsets.py
+++ b/pulp_maven/app/viewsets.py
@@ -15,6 +15,7 @@ from pulpcore.plugin.viewsets import (
     RemoteViewSet,
     RepositoryVersionViewSet,
     RepositoryViewSet,
+    RolesMixin,
     SingleArtifactContentUploadViewSet,
 )
 
@@ -47,7 +48,7 @@ class MavenArtifactFilter(ContentFilter):
 
     class Meta:
         model = MavenArtifact
-        fields = ["group_id", "artifact_id", "version", "filename"]
+        fields = ["group_id", "artifact_id", "version", "filename"]  # noqa: RUF012
 
 
 class MavenArtifactViewSet(SingleArtifactContentUploadViewSet):
@@ -59,6 +60,43 @@ class MavenArtifactViewSet(SingleArtifactContentUploadViewSet):
     queryset = MavenArtifact.objects.all()
     serializer_class = MavenArtifactSerializer
     filterset_class = MavenArtifactFilter
+
+    DEFAULT_ACCESS_POLICY = {  # noqa: RUF012
+        "statements": [
+            {
+                "action": ["list", "retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_required_repo_perms_on_upload:maven.modify_mavenrepository",
+                    "has_required_repo_perms_on_upload:maven.view_mavenrepository",
+                    "has_upload_param_model_or_domain_or_obj_perms:core.change_upload",
+                ],
+            },
+            {
+                "action": ["upload"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_perms:maven.add_mavenartifact",
+                ],
+            },
+            {
+                "action": ["set_label", "unset_label"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_perms:core.manage_content_labels",
+                ],
+            },
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
 
     @extend_schema(
         description="Synchronously upload a Maven artifact.",
@@ -85,7 +123,7 @@ class MavenMetadataFilter(ContentFilter):
 
     class Meta:
         model = MavenMetadata
-        fields = ["group_id", "artifact_id", "version", "filename"]
+        fields = ["group_id", "artifact_id", "version", "filename"]  # noqa: RUF012
 
 
 class MavenMetadataViewSet(SingleArtifactContentUploadViewSet):
@@ -97,6 +135,43 @@ class MavenMetadataViewSet(SingleArtifactContentUploadViewSet):
     queryset = MavenMetadata.objects.all()
     serializer_class = MavenMetadataSerializer
     filterset_class = MavenMetadataFilter
+
+    DEFAULT_ACCESS_POLICY = {  # noqa: RUF012
+        "statements": [
+            {
+                "action": ["list", "retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_required_repo_perms_on_upload:maven.modify_mavenrepository",
+                    "has_required_repo_perms_on_upload:maven.view_mavenrepository",
+                    "has_upload_param_model_or_domain_or_obj_perms:core.change_upload",
+                ],
+            },
+            {
+                "action": ["upload"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_perms:maven.add_mavenmetadata",
+                ],
+            },
+            {
+                "action": ["set_label", "unset_label"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_perms:core.manage_content_labels",
+                ],
+            },
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
 
     @extend_schema(
         description="Synchronously upload a Maven metadata file.",
@@ -123,7 +198,7 @@ class MavenPackageFilter(ContentFilter):
 
     class Meta:
         model = MavenPackage
-        fields = ["group_id", "artifact_id", "version", "name", "packaging"]
+        fields = ["group_id", "artifact_id", "version", "name", "packaging"]  # noqa: RUF012
 
 
 class MavenPackageViewSet(ReadOnlyContentViewSet):
@@ -140,8 +215,19 @@ class MavenPackageViewSet(ReadOnlyContentViewSet):
     serializer_class = MavenPackageSerializer
     filterset_class = MavenPackageFilter
 
+    DEFAULT_ACCESS_POLICY = {  # noqa: RUF012
+        "statements": [
+            {
+                "action": ["list", "retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
 
-class MavenRemoteViewSet(RemoteViewSet):
+
+class MavenRemoteViewSet(RemoteViewSet, RolesMixin):
     """
     A ViewSet for MavenRemote.
     """
@@ -150,15 +236,199 @@ class MavenRemoteViewSet(RemoteViewSet):
     queryset = MavenRemote.objects.all()
     serializer_class = MavenRemoteSerializer
 
+    queryset_filtering_required_permission = "maven.view_mavenremote"
 
-class MavenRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin):
+    DEFAULT_ACCESS_POLICY = {  # noqa: RUF012
+        "statements": [
+            {
+                "action": ["list", "my_permissions"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_perms:maven.add_mavenremote",
+            },
+            {
+                "action": ["retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:maven.view_mavenremote",
+            },
+            {
+                "action": ["update", "partial_update"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.change_mavenremote",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenremote",
+                ],
+            },
+            {
+                "action": ["set_label", "unset_label"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.change_mavenremote",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenremote",
+                ],
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.delete_mavenremote",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenremote",
+                ],
+            },
+            {
+                "action": ["list_roles", "add_role", "remove_role"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": ["has_model_or_domain_or_obj_perms:maven.manage_roles_mavenremote"],
+            },
+        ],
+        "creation_hooks": [
+            {
+                "function": "add_roles_for_object_creator",
+                "parameters": {"roles": "maven.mavenremote_owner"},
+            },
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+    LOCKED_ROLES = {  # noqa: RUF012
+        "maven.mavenremote_creator": ["maven.add_mavenremote"],
+        "maven.mavenremote_owner": [
+            "maven.view_mavenremote",
+            "maven.change_mavenremote",
+            "maven.delete_mavenremote",
+            "maven.manage_roles_mavenremote",
+        ],
+        "maven.mavenremote_viewer": ["maven.view_mavenremote"],
+    }
+
+
+class MavenRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin, RolesMixin):
     """
-    A ViewSet for MavenRemote.
+    A ViewSet for MavenRepository.
     """
 
     endpoint_name = "maven"
     queryset = MavenRepository.objects.all()
     serializer_class = MavenRepositorySerializer
+
+    queryset_filtering_required_permission = "maven.view_mavenrepository"
+
+    DEFAULT_ACCESS_POLICY = {  # noqa: RUF012
+        "statements": [
+            {
+                "action": ["list", "my_permissions"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_perms:maven.add_mavenrepository",
+                    "has_remote_param_model_or_domain_or_obj_perms:maven.view_mavenremote",
+                ],
+            },
+            {
+                "action": ["retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+            },
+            {
+                "action": ["update", "partial_update"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.change_mavenrepository",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                    "has_remote_param_model_or_domain_or_obj_perms:maven.view_mavenremote",
+                ],
+            },
+            {
+                "action": ["set_label", "unset_label"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.change_mavenrepository",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.delete_mavenrepository",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["add_cached_content"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.modify_mavenrepository",
+                    "has_remote_param_model_or_domain_or_obj_perms:maven.view_mavenremote",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["repair_metadata"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.repair_mavenrepository",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["modify"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.modify_mavenrepository",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["list_roles", "add_role", "remove_role"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.manage_roles_mavenrepository"
+                ],
+            },
+        ],
+        "creation_hooks": [
+            {
+                "function": "add_roles_for_object_creator",
+                "parameters": {"roles": "maven.mavenrepository_owner"},
+            },
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+    LOCKED_ROLES = {  # noqa: RUF012
+        "maven.mavenrepository_creator": ["maven.add_mavenrepository"],
+        "maven.mavenrepository_owner": [
+            "maven.view_mavenrepository",
+            "maven.change_mavenrepository",
+            "maven.delete_mavenrepository",
+            "maven.modify_mavenrepository",
+            "maven.repair_mavenrepository",
+            "maven.manage_roles_mavenrepository",
+        ],
+        "maven.mavenrepository_viewer": ["maven.view_mavenrepository"],
+    }
 
     @extend_schema(
         description="Trigger an asynchronous task to add cached content to a repository.",
@@ -222,8 +492,37 @@ class MavenRepositoryVersionViewSet(RepositoryVersionViewSet):
 
     parent_viewset = MavenRepositoryViewSet
 
+    DEFAULT_ACCESS_POLICY = {  # noqa: RUF012
+        "statements": [
+            {
+                "action": ["list", "retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_repository_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_repository_model_or_domain_or_obj_perms:maven.delete_mavenrepository",
+                    "has_repository_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["repair"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_repository_model_or_domain_or_obj_perms:maven.repair_mavenrepository",
+                    "has_repository_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+        ],
+    }
 
-class MavenDistributionViewSet(DistributionViewSet):
+
+class MavenDistributionViewSet(DistributionViewSet, RolesMixin):
     """
     ViewSet for Maven Distributions.
     """
@@ -231,3 +530,83 @@ class MavenDistributionViewSet(DistributionViewSet):
     endpoint_name = "maven"
     queryset = MavenDistribution.objects.all()
     serializer_class = MavenDistributionSerializer
+
+    queryset_filtering_required_permission = "maven.view_mavendistribution"
+
+    DEFAULT_ACCESS_POLICY = {  # noqa: RUF012
+        "statements": [
+            {
+                "action": ["list", "my_permissions"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_perms:maven.add_mavendistribution",
+                    "has_repo_or_repo_ver_param_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["retrieve"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "has_model_or_domain_or_obj_perms:maven.view_mavendistribution",
+            },
+            {
+                "action": ["update", "partial_update"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.change_mavendistribution",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavendistribution",
+                    "has_repo_or_repo_ver_param_model_or_domain_or_obj_perms:maven.view_mavenrepository",
+                ],
+            },
+            {
+                "action": ["set_label", "unset_label"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.change_mavendistribution",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavendistribution",
+                ],
+            },
+            {
+                "action": ["destroy"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.delete_mavendistribution",
+                    "has_model_or_domain_or_obj_perms:maven.view_mavendistribution",
+                ],
+            },
+            {
+                "action": ["list_roles", "add_role", "remove_role"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_or_domain_or_obj_perms:maven.manage_roles_mavendistribution"
+                ],
+            },
+        ],
+        "creation_hooks": [
+            {
+                "function": "add_roles_for_object_creator",
+                "parameters": {"roles": "maven.mavendistribution_owner"},
+            },
+        ],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+    LOCKED_ROLES = {  # noqa: RUF012
+        "maven.mavendistribution_creator": ["maven.add_mavendistribution"],
+        "maven.mavendistribution_owner": [
+            "maven.view_mavendistribution",
+            "maven.change_mavendistribution",
+            "maven.delete_mavendistribution",
+            "maven.manage_roles_mavendistribution",
+        ],
+        "maven.mavendistribution_viewer": ["maven.view_mavendistribution"],
+    }

--- a/pulp_maven/tests/functional/api/conftest.py
+++ b/pulp_maven/tests/functional/api/conftest.py
@@ -1,0 +1,14 @@
+from pulp_maven.tests.functional.conftest import (  # noqa: F401
+    maven_artifact_api_client,
+    maven_bindings,
+    maven_client,
+    maven_distribution_factory,
+    maven_distro_api_client,
+    maven_metadata_api_client,
+    maven_package_api_client,
+    maven_remote_api_client,
+    maven_remote_factory,
+    maven_repo_api_client,
+    maven_repo_factory,
+    pom_file_factory,
+)

--- a/pulp_maven/tests/functional/api/test_rbac.py
+++ b/pulp_maven/tests/functional/api/test_rbac.py
@@ -1,0 +1,916 @@
+import uuid
+
+import pytest
+
+
+@pytest.fixture()
+def gen_users(gen_user):
+    """Returns a user generator function for the tests."""
+
+    def _gen_users(role_names=None):
+        if role_names is None:
+            role_names = []
+        if isinstance(role_names, str):
+            role_names = [role_names]
+        viewer_roles = [f"maven.{role}_viewer" for role in role_names]
+        creator_roles = [f"maven.{role}_creator" for role in role_names]
+        alice = gen_user(model_roles=viewer_roles)
+        bob = gen_user(model_roles=creator_roles)
+        charlie = gen_user()
+        return alice, bob, charlie
+
+    return _gen_users
+
+
+@pytest.fixture
+def try_action(maven_bindings, monitor_task):
+    def _try_action(user, client, action, outcome, *args, **kwargs):
+        action_api = getattr(client, f"{action}_with_http_info")
+        try:
+            with user:
+                response = action_api(*args, **kwargs)
+            if isinstance(response, tuple):
+                data, status_code, _ = response
+            else:
+                data = response.data
+                status_code = response.status_code
+            if isinstance(data, maven_bindings.module.AsyncOperationResponse):
+                data = monitor_task(data.task)
+        except maven_bindings.module.ApiException as e:
+            assert e.status == outcome, f"{e}"
+        else:
+            assert status_code == outcome, (
+                f"User performed {action} when they shouldn't have been able to"
+            )
+            return data
+
+    return _try_action
+
+
+@pytest.mark.parallel
+def test_basic_actions(gen_users, maven_bindings, try_action, maven_repo_factory):
+    """Test list, read, create, update and delete on repositories."""
+    alice, bob, charlie = gen_users("mavenrepository")
+
+    a_list = try_action(alice, maven_bindings.RepositoriesMavenApi, "list", 200)
+    assert a_list.count >= 1
+    b_list = try_action(bob, maven_bindings.RepositoriesMavenApi, "list", 200)
+    c_list = try_action(charlie, maven_bindings.RepositoriesMavenApi, "list", 200)
+    assert (b_list.count, c_list.count) == (0, 0)
+
+    # Create testing
+    try_action(
+        alice,
+        maven_bindings.RepositoriesMavenApi,
+        "create",
+        403,
+        {"name": str(uuid.uuid4())},
+    )
+    repo = try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "create",
+        201,
+        {"name": str(uuid.uuid4())},
+    )
+    try_action(
+        charlie,
+        maven_bindings.RepositoriesMavenApi,
+        "create",
+        403,
+        {"name": str(uuid.uuid4())},
+    )
+
+    # View testing
+    try_action(alice, maven_bindings.RepositoriesMavenApi, "read", 200, repo.pulp_href)
+    try_action(bob, maven_bindings.RepositoriesMavenApi, "read", 200, repo.pulp_href)
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "read", 404, repo.pulp_href)
+
+    # Update testing
+    update_args = [repo.pulp_href, {"name": str(uuid.uuid4())}]
+    try_action(
+        alice,
+        maven_bindings.RepositoriesMavenApi,
+        "partial_update",
+        403,
+        *update_args,
+    )
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "partial_update",
+        202,
+        *update_args,
+    )
+    try_action(
+        charlie,
+        maven_bindings.RepositoriesMavenApi,
+        "partial_update",
+        404,
+        *update_args,
+    )
+
+    # Delete testing
+    try_action(alice, maven_bindings.RepositoriesMavenApi, "delete", 403, repo.pulp_href)
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "delete", 404, repo.pulp_href)
+    try_action(bob, maven_bindings.RepositoriesMavenApi, "delete", 202, repo.pulp_href)
+
+
+@pytest.mark.parallel
+def test_repository_actions(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    maven_remote_factory,
+    try_action,
+):
+    """Test add_cached_content, repair_metadata, and modify actions."""
+    alice, bob, charlie = gen_users(["mavenrepository", "mavenremote"])
+
+    with bob:
+        bob_remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+        repo = maven_repo_factory(remote=bob_remote.pulp_href)
+
+    # add_cached_content tests
+    body = {"remote": bob_remote.pulp_href}
+    try_action(
+        alice,
+        maven_bindings.RepositoriesMavenApi,
+        "add_cached_content",
+        403,
+        repo.pulp_href,
+        body,
+    )
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "add_cached_content",
+        202,
+        repo.pulp_href,
+        body,
+    )
+    try_action(
+        charlie,
+        maven_bindings.RepositoriesMavenApi,
+        "add_cached_content",
+        404,
+        repo.pulp_href,
+        body,
+    )
+
+    # repair_metadata tests
+    try_action(
+        alice,
+        maven_bindings.RepositoriesMavenApi,
+        "repair_metadata",
+        403,
+        repo.pulp_href,
+    )
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "repair_metadata",
+        202,
+        repo.pulp_href,
+    )
+    try_action(
+        charlie,
+        maven_bindings.RepositoriesMavenApi,
+        "repair_metadata",
+        404,
+        repo.pulp_href,
+    )
+
+    # modify tests
+    try_action(
+        alice,
+        maven_bindings.RepositoriesMavenApi,
+        "modify",
+        403,
+        repo.pulp_href,
+        {},
+    )
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "modify",
+        202,
+        repo.pulp_href,
+        {},
+    )
+    try_action(
+        charlie,
+        maven_bindings.RepositoriesMavenApi,
+        "modify",
+        404,
+        repo.pulp_href,
+        {},
+    )
+
+
+@pytest.mark.parallel
+def test_repository_version_actions(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    try_action,
+):
+    """Test list, retrieve, destroy, and repair on repository versions."""
+    alice, bob, charlie = gen_users("mavenrepository")
+    with bob:
+        repo = maven_repo_factory()
+
+    # Trigger a modify to create version 1 (version 0 is the initial empty version)
+    with bob:
+        try_action(bob, maven_bindings.RepositoriesMavenApi, "modify", 202, repo.pulp_href, {})
+        # Re-read the repo to get the updated latest_version_href
+        repo = maven_bindings.RepositoriesMavenApi.read(repo.pulp_href)
+
+    ver_href = repo.latest_version_href
+
+    # List versions
+    a_vers = try_action(
+        alice, maven_bindings.RepositoriesMavenVersionsApi, "list", 200, repo.pulp_href
+    )
+    assert a_vers.count >= 1
+    b_vers = try_action(
+        bob, maven_bindings.RepositoriesMavenVersionsApi, "list", 200, repo.pulp_href
+    )
+    assert b_vers.count >= 1
+    try_action(
+        charlie,
+        maven_bindings.RepositoriesMavenVersionsApi,
+        "list",
+        403,
+        repo.pulp_href,
+    )
+
+    # Retrieve specific version
+    try_action(alice, maven_bindings.RepositoriesMavenVersionsApi, "read", 200, ver_href)
+    try_action(bob, maven_bindings.RepositoriesMavenVersionsApi, "read", 200, ver_href)
+    try_action(charlie, maven_bindings.RepositoriesMavenVersionsApi, "read", 403, ver_href)
+
+    # Destroy version — permission checks only (don't execute bob's delete
+    # as deleting the only version fails with PLP0011)
+    try_action(alice, maven_bindings.RepositoriesMavenVersionsApi, "delete", 403, ver_href)
+    try_action(charlie, maven_bindings.RepositoriesMavenVersionsApi, "delete", 403, ver_href)
+
+
+@pytest.mark.parallel
+def test_content_viewset_permissions(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    random_artifact_factory,
+    monitor_task,
+    try_action,
+):
+    """Test that content listing is scoped by repository view permissions."""
+    alice, bob, charlie = gen_users("mavenrepository")
+
+    # Admin creates repo and uploads content
+    repo = maven_repo_factory()
+    artifact = random_artifact_factory(size=64)
+    content = maven_bindings.ContentArtifactApi.upload(
+        artifact=artifact.pulp_href,
+        relative_path="com/example/test-rbac/1.0.0/test-rbac-1.0.0.jar",
+    )
+    monitor_task(
+        maven_bindings.RepositoriesMavenApi.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+
+    # Alice (viewer) can see content in repo she has view perms on
+    a_list = try_action(alice, maven_bindings.ContentArtifactApi, "list", 200)
+    assert a_list.count >= 1
+
+    # Bob (creator, no view on admin repo) sees no content
+    b_list = try_action(bob, maven_bindings.ContentArtifactApi, "list", 200)
+    assert b_list.count == 0
+
+    # Charlie (no roles) sees no content
+    c_list = try_action(charlie, maven_bindings.ContentArtifactApi, "list", 200)
+    assert c_list.count == 0
+
+    # Grant charlie object-level viewer role on the repo
+    maven_bindings.RepositoriesMavenApi.add_role(
+        repo.pulp_href,
+        {"users": [charlie.username], "role": "maven.mavenrepository_viewer"},
+    )
+
+    # Now charlie can see the content
+    c_list2 = try_action(charlie, maven_bindings.ContentArtifactApi, "list", 200)
+    assert c_list2.count >= 1
+
+
+@pytest.mark.parallel
+def test_cross_object_permissions(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    maven_remote_factory,
+    try_action,
+):
+    """Test that cross-object references enforce permissions on referenced objects."""
+    _alice, bob, _charlie = gen_users(["mavenrepository", "mavenremote", "mavendistribution"])
+
+    # Admin creates resources
+    admin_repo = maven_repo_factory()
+    admin_remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+
+    # Bob creates his own resources
+    with bob:
+        bob_remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+        bob_repo = maven_repo_factory()
+
+    # Distribution creation: bob cannot reference admin repo (lacks view perm)
+    try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "create",
+        403,
+        {
+            "name": str(uuid.uuid4()),
+            "base_path": str(uuid.uuid4()),
+            "repository": admin_repo.pulp_href,
+        },
+    )
+
+    # Distribution creation: bob can reference own repo
+    distro = try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "create",
+        202,
+        {
+            "name": str(uuid.uuid4()),
+            "base_path": str(uuid.uuid4()),
+            "repository": bob_repo.pulp_href,
+        },
+    )
+    distro_href = distro.created_resources[0]
+
+    # Distribution update: bob cannot switch to admin repo
+    try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "partial_update",
+        403,
+        distro_href,
+        {"repository": admin_repo.pulp_href},
+    )
+
+    # Distribution update: bob can switch to own repo (same repo, tests the perm check)
+    try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "partial_update",
+        202,
+        distro_href,
+        {"repository": bob_repo.pulp_href},
+    )
+
+    # Repository creation: bob cannot reference admin remote
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "create",
+        403,
+        {"name": str(uuid.uuid4()), "remote": admin_remote.pulp_href},
+    )
+
+    # Repository creation: bob can reference own remote
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "create",
+        201,
+        {"name": str(uuid.uuid4()), "remote": bob_remote.pulp_href},
+    )
+
+
+@pytest.mark.parallel
+def test_remote_actions(gen_users, maven_bindings, try_action):
+    """Test CRUD on remotes with role-based access."""
+    alice, bob, charlie = gen_users("mavenremote")
+
+    a_list = try_action(alice, maven_bindings.RemotesMavenApi, "list", 200)
+    assert a_list.count >= 0
+    b_list = try_action(bob, maven_bindings.RemotesMavenApi, "list", 200)
+    c_list = try_action(charlie, maven_bindings.RemotesMavenApi, "list", 200)
+    assert (b_list.count, c_list.count) == (0, 0)
+
+    # Create
+    remote_body = {
+        "name": str(uuid.uuid4()),
+        "url": "https://repo1.maven.org/maven2/",
+    }
+    try_action(alice, maven_bindings.RemotesMavenApi, "create", 403, remote_body)
+    remote = try_action(bob, maven_bindings.RemotesMavenApi, "create", 201, remote_body)
+    try_action(charlie, maven_bindings.RemotesMavenApi, "create", 403, remote_body)
+
+    # Read
+    try_action(alice, maven_bindings.RemotesMavenApi, "read", 200, remote.pulp_href)
+    try_action(bob, maven_bindings.RemotesMavenApi, "read", 200, remote.pulp_href)
+    try_action(charlie, maven_bindings.RemotesMavenApi, "read", 404, remote.pulp_href)
+
+    # Update
+    update_args = [remote.pulp_href, {"name": str(uuid.uuid4())}]
+    try_action(alice, maven_bindings.RemotesMavenApi, "partial_update", 403, *update_args)
+    try_action(bob, maven_bindings.RemotesMavenApi, "partial_update", 202, *update_args)
+    try_action(charlie, maven_bindings.RemotesMavenApi, "partial_update", 404, *update_args)
+
+    # Delete
+    try_action(alice, maven_bindings.RemotesMavenApi, "delete", 403, remote.pulp_href)
+    try_action(charlie, maven_bindings.RemotesMavenApi, "delete", 404, remote.pulp_href)
+    try_action(bob, maven_bindings.RemotesMavenApi, "delete", 202, remote.pulp_href)
+
+
+@pytest.mark.parallel
+def test_remote_role_management(
+    gen_users,
+    maven_bindings,
+    maven_remote_factory,
+    try_action,
+):
+    """Test role management APIs on remotes."""
+    alice, bob, charlie = gen_users("mavenremote")
+    with bob:
+        remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+
+    # list_roles
+    try_action(alice, maven_bindings.RemotesMavenApi, "list_roles", 403, remote.pulp_href)
+    try_action(bob, maven_bindings.RemotesMavenApi, "list_roles", 200, remote.pulp_href)
+
+    # add_role — give charlie viewer
+    nested_role = {
+        "users": [charlie.username],
+        "role": "maven.mavenremote_viewer",
+    }
+    try_action(
+        alice, maven_bindings.RemotesMavenApi, "add_role", 403, remote.pulp_href, nested_role
+    )
+    try_action(bob, maven_bindings.RemotesMavenApi, "add_role", 201, remote.pulp_href, nested_role)
+
+    # charlie can now see the remote
+    try_action(charlie, maven_bindings.RemotesMavenApi, "read", 200, remote.pulp_href)
+
+    # remove_role — revoke charlie's viewer
+    try_action(
+        alice, maven_bindings.RemotesMavenApi, "remove_role", 403, remote.pulp_href, nested_role
+    )
+    try_action(
+        bob, maven_bindings.RemotesMavenApi, "remove_role", 201, remote.pulp_href, nested_role
+    )
+
+    # charlie can no longer see the remote
+    try_action(charlie, maven_bindings.RemotesMavenApi, "read", 404, remote.pulp_href)
+
+
+@pytest.mark.parallel
+def test_distribution_actions(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    try_action,
+):
+    """Test CRUD on distributions with role-based access."""
+    alice, bob, charlie = gen_users(["mavendistribution", "mavenrepository"])
+
+    with bob:
+        repo = maven_repo_factory()
+
+    # Create
+    try_action(
+        alice,
+        maven_bindings.DistributionsMavenApi,
+        "create",
+        403,
+        {
+            "name": str(uuid.uuid4()),
+            "base_path": str(uuid.uuid4()),
+            "repository": repo.pulp_href,
+        },
+    )
+    distro = try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "create",
+        202,
+        {
+            "name": str(uuid.uuid4()),
+            "base_path": str(uuid.uuid4()),
+            "repository": repo.pulp_href,
+        },
+    )
+    distro_href = distro.created_resources[0]
+    try_action(
+        charlie,
+        maven_bindings.DistributionsMavenApi,
+        "create",
+        403,
+        {
+            "name": str(uuid.uuid4()),
+            "base_path": str(uuid.uuid4()),
+            "repository": repo.pulp_href,
+        },
+    )
+
+    # Read
+    try_action(alice, maven_bindings.DistributionsMavenApi, "read", 200, distro_href)
+    try_action(bob, maven_bindings.DistributionsMavenApi, "read", 200, distro_href)
+    try_action(charlie, maven_bindings.DistributionsMavenApi, "read", 404, distro_href)
+
+    # Update
+    update_args = [distro_href, {"name": str(uuid.uuid4())}]
+    try_action(
+        alice,
+        maven_bindings.DistributionsMavenApi,
+        "partial_update",
+        403,
+        *update_args,
+    )
+    try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "partial_update",
+        202,
+        *update_args,
+    )
+    try_action(
+        charlie,
+        maven_bindings.DistributionsMavenApi,
+        "partial_update",
+        404,
+        *update_args,
+    )
+
+    # Delete
+    try_action(alice, maven_bindings.DistributionsMavenApi, "delete", 403, distro_href)
+    try_action(charlie, maven_bindings.DistributionsMavenApi, "delete", 404, distro_href)
+    try_action(bob, maven_bindings.DistributionsMavenApi, "delete", 202, distro_href)
+
+
+@pytest.mark.parallel
+def test_distribution_role_management(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    try_action,
+):
+    """Test role management APIs on distributions."""
+    alice, bob, charlie = gen_users(["mavendistribution", "mavenrepository"])
+    with bob:
+        repo = maven_repo_factory()
+
+    distro = try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "create",
+        202,
+        {
+            "name": str(uuid.uuid4()),
+            "base_path": str(uuid.uuid4()),
+            "repository": repo.pulp_href,
+        },
+    )
+    distro_href = distro.created_resources[0]
+
+    # list_roles
+    try_action(alice, maven_bindings.DistributionsMavenApi, "list_roles", 403, distro_href)
+    try_action(bob, maven_bindings.DistributionsMavenApi, "list_roles", 200, distro_href)
+
+    # add_role — give charlie viewer
+    nested_role = {
+        "users": [charlie.username],
+        "role": "maven.mavendistribution_viewer",
+    }
+    try_action(
+        alice,
+        maven_bindings.DistributionsMavenApi,
+        "add_role",
+        403,
+        distro_href,
+        nested_role,
+    )
+    try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "add_role",
+        201,
+        distro_href,
+        nested_role,
+    )
+
+    # charlie can now see the distribution
+    try_action(charlie, maven_bindings.DistributionsMavenApi, "read", 200, distro_href)
+
+    # remove_role — revoke charlie's viewer
+    try_action(
+        alice,
+        maven_bindings.DistributionsMavenApi,
+        "remove_role",
+        403,
+        distro_href,
+        nested_role,
+    )
+    try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "remove_role",
+        201,
+        distro_href,
+        nested_role,
+    )
+
+    # charlie can no longer see the distribution
+    try_action(charlie, maven_bindings.DistributionsMavenApi, "read", 404, distro_href)
+
+
+@pytest.mark.parallel
+def test_label_operations(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    try_action,
+):
+    """Test set_label and unset_label on repositories."""
+    alice, bob, charlie = gen_users("mavenrepository")
+    with bob:
+        repo = maven_repo_factory()
+
+    label_args = [repo.pulp_href, {"key": "test", "value": "val"}]
+    try_action(alice, maven_bindings.RepositoriesMavenApi, "set_label", 403, *label_args)
+    try_action(bob, maven_bindings.RepositoriesMavenApi, "set_label", 201, *label_args)
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "set_label", 404, *label_args)
+
+    unlabel_args = [repo.pulp_href, {"key": "test"}]
+    try_action(alice, maven_bindings.RepositoriesMavenApi, "unset_label", 403, *unlabel_args)
+    try_action(bob, maven_bindings.RepositoriesMavenApi, "unset_label", 201, *unlabel_args)
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "unset_label", 404, *unlabel_args)
+
+
+@pytest.mark.parallel
+def test_remote_label_operations(
+    gen_users,
+    maven_bindings,
+    maven_remote_factory,
+    try_action,
+):
+    """Test set_label and unset_label on remotes."""
+    alice, bob, charlie = gen_users("mavenremote")
+    with bob:
+        remote = maven_remote_factory(url="https://repo1.maven.org/maven2/")
+
+    label_args = [remote.pulp_href, {"key": "test", "value": "val"}]
+    try_action(alice, maven_bindings.RemotesMavenApi, "set_label", 403, *label_args)
+    try_action(bob, maven_bindings.RemotesMavenApi, "set_label", 201, *label_args)
+    try_action(charlie, maven_bindings.RemotesMavenApi, "set_label", 404, *label_args)
+
+    unlabel_args = [remote.pulp_href, {"key": "test"}]
+    try_action(alice, maven_bindings.RemotesMavenApi, "unset_label", 403, *unlabel_args)
+    try_action(bob, maven_bindings.RemotesMavenApi, "unset_label", 201, *unlabel_args)
+    try_action(charlie, maven_bindings.RemotesMavenApi, "unset_label", 404, *unlabel_args)
+
+
+@pytest.mark.parallel
+def test_distribution_label_operations(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    try_action,
+):
+    """Test set_label and unset_label on distributions."""
+    alice, bob, charlie = gen_users(["mavendistribution", "mavenrepository"])
+    with bob:
+        repo = maven_repo_factory()
+
+    distro = try_action(
+        bob,
+        maven_bindings.DistributionsMavenApi,
+        "create",
+        202,
+        {
+            "name": str(uuid.uuid4()),
+            "base_path": str(uuid.uuid4()),
+            "repository": repo.pulp_href,
+        },
+    )
+    distro_href = distro.created_resources[0]
+
+    label_args = [distro_href, {"key": "test", "value": "val"}]
+    try_action(alice, maven_bindings.DistributionsMavenApi, "set_label", 403, *label_args)
+    try_action(bob, maven_bindings.DistributionsMavenApi, "set_label", 201, *label_args)
+    try_action(charlie, maven_bindings.DistributionsMavenApi, "set_label", 404, *label_args)
+
+    unlabel_args = [distro_href, {"key": "test"}]
+    try_action(alice, maven_bindings.DistributionsMavenApi, "unset_label", 403, *unlabel_args)
+    try_action(bob, maven_bindings.DistributionsMavenApi, "unset_label", 201, *unlabel_args)
+    try_action(
+        charlie,
+        maven_bindings.DistributionsMavenApi,
+        "unset_label",
+        404,
+        *unlabel_args,
+    )
+
+
+@pytest.mark.parallel
+def test_content_label_operations(
+    gen_user,
+    maven_bindings,
+    maven_repo_factory,
+    random_artifact_factory,
+    monitor_task,
+    try_action,
+):
+    """Test set_label and unset_label on content (MavenArtifact)."""
+    label_user = gen_user(model_roles=["core.content_labeler", "maven.mavenrepository_viewer"])
+    no_perm_user = gen_user()
+
+    repo = maven_repo_factory()
+    artifact = random_artifact_factory(size=64)
+    content = maven_bindings.ContentArtifactApi.upload(
+        artifact=artifact.pulp_href,
+        relative_path="com/example/test-label/1.0.0/test-label-1.0.0.jar",
+    )
+    monitor_task(
+        maven_bindings.RepositoriesMavenApi.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+
+    label_args = [content.pulp_href, {"key": "env", "value": "test"}]
+    try_action(label_user, maven_bindings.ContentArtifactApi, "set_label", 201, *label_args)
+    try_action(no_perm_user, maven_bindings.ContentArtifactApi, "set_label", 403, *label_args)
+
+    unlabel_args = [content.pulp_href, {"key": "env"}]
+    try_action(
+        label_user,
+        maven_bindings.ContentArtifactApi,
+        "unset_label",
+        201,
+        *unlabel_args,
+    )
+    try_action(
+        no_perm_user,
+        maven_bindings.ContentArtifactApi,
+        "unset_label",
+        403,
+        *unlabel_args,
+    )
+
+
+@pytest.mark.parallel
+def test_role_management(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    try_action,
+):
+    """Test role management APIs on repositories."""
+    alice, bob, charlie = gen_users("mavenrepository")
+    with bob:
+        href = maven_repo_factory().pulp_href
+
+    # my_permissions
+    aperm = try_action(alice, maven_bindings.RepositoriesMavenApi, "my_permissions", 200, href)
+    assert aperm.permissions == []
+    bperm = try_action(bob, maven_bindings.RepositoriesMavenApi, "my_permissions", 200, href)
+    assert len(bperm.permissions) > 0
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "my_permissions", 404, href)
+
+    # list_roles / add_role / remove_role
+    try_action(alice, maven_bindings.RepositoriesMavenApi, "list_roles", 403, href)
+    try_action(bob, maven_bindings.RepositoriesMavenApi, "list_roles", 200, href)
+
+    nested_role = {
+        "users": [charlie.username],
+        "role": "maven.mavenrepository_viewer",
+    }
+    try_action(
+        alice,
+        maven_bindings.RepositoriesMavenApi,
+        "add_role",
+        403,
+        href,
+        nested_role,
+    )
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "add_role",
+        201,
+        href,
+        nested_role,
+    )
+
+    # charlie can now see the repo
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "read", 200, href)
+
+    # remove_role
+    try_action(
+        alice,
+        maven_bindings.RepositoriesMavenApi,
+        "remove_role",
+        403,
+        href,
+        nested_role,
+    )
+    try_action(
+        bob,
+        maven_bindings.RepositoriesMavenApi,
+        "remove_role",
+        201,
+        href,
+        nested_role,
+    )
+
+    # charlie can no longer see the repo
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "read", 404, href)
+
+
+@pytest.mark.parallel
+def test_object_level_roles(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    try_action,
+):
+    """Test that object-level roles grant access to specific objects only."""
+    _alice, bob, charlie = gen_users("mavenrepository")
+
+    with bob:
+        repo_a = maven_repo_factory()
+        repo_b = maven_repo_factory()
+
+    # charlie cannot see either repo
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "read", 404, repo_a.pulp_href)
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "read", 404, repo_b.pulp_href)
+
+    # Grant charlie object-level viewer on repo_a only
+    with bob:
+        maven_bindings.RepositoriesMavenApi.add_role(
+            repo_a.pulp_href,
+            {"users": [charlie.username], "role": "maven.mavenrepository_viewer"},
+        )
+
+    # charlie can see repo_a but not repo_b
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "read", 200, repo_a.pulp_href)
+    try_action(charlie, maven_bindings.RepositoriesMavenApi, "read", 404, repo_b.pulp_href)
+
+    # charlie's list returns only repo_a
+    c_list = try_action(charlie, maven_bindings.RepositoriesMavenApi, "list", 200)
+    assert c_list.count == 1
+
+
+@pytest.mark.parallel
+def test_package_viewset_permissions(
+    gen_users,
+    maven_bindings,
+    maven_repo_factory,
+    pom_file_factory,
+    monitor_task,
+    try_action,
+):
+    """Test that package listing is scoped by repository view permissions."""
+    alice, bob, charlie = gen_users("mavenrepository")
+
+    repo = maven_repo_factory()
+    pom_path = pom_file_factory(
+        group_id="com.example.rbac",
+        artifact_id="pkg-perm-test",
+        version="1.0.0",
+    )
+    content = maven_bindings.ContentArtifactApi.upload(
+        file=str(pom_path),
+        relative_path="com/example/rbac/pkg-perm-test/1.0.0/pkg-perm-test-1.0.0.pom",
+    )
+    monitor_task(
+        maven_bindings.RepositoriesMavenApi.modify(
+            repo.pulp_href, {"add_content_units": [content.pulp_href]}
+        ).task
+    )
+
+    # Alice (viewer) can see packages
+    a_list = try_action(alice, maven_bindings.ContentPackageApi, "list", 200)
+    assert a_list.count >= 1
+
+    # Bob (creator, no view on admin repo) sees no packages
+    b_list = try_action(bob, maven_bindings.ContentPackageApi, "list", 200)
+    assert b_list.count == 0
+
+    # Charlie (no roles) sees no packages
+    c_list = try_action(charlie, maven_bindings.ContentPackageApi, "list", 200)
+    assert c_list.count == 0
+
+    # Grant charlie object-level viewer role on the repo
+    maven_bindings.RepositoriesMavenApi.add_role(
+        repo.pulp_href,
+        {"users": [charlie.username], "role": "maven.mavenrepository_viewer"},
+    )
+
+    # Now charlie can see the packages
+    c_list2 = try_action(charlie, maven_bindings.ContentPackageApi, "list", 200)
+    assert c_list2.count >= 1

--- a/pulp_maven/tests/functional/conftest.py
+++ b/pulp_maven/tests/functional/conftest.py
@@ -11,6 +11,7 @@ from pulpcore.client.pulp_maven import (
     RemotesMavenApi,
     RepositoriesMavenApi,
 )
+from pulpcore.tests.functional.utils import BindingsNamespace
 
 
 @pytest.fixture(scope="session")
@@ -18,6 +19,17 @@ def maven_client(_api_client_set, bindings_cfg):
     api_client = ApiClient(bindings_cfg)
     _api_client_set.add(api_client)
     yield api_client
+    _api_client_set.remove(api_client)
+
+
+@pytest.fixture(scope="session")
+def maven_bindings(_api_client_set, bindings_cfg):
+    """A namespace providing preconfigured pulp_maven API clients."""
+    from pulpcore.client import pulp_maven as maven_bindings_module
+
+    api_client = maven_bindings_module.ApiClient(bindings_cfg)
+    _api_client_set.add(api_client)
+    yield BindingsNamespace(maven_bindings_module, api_client)
     _api_client_set.remove(api_client)
 
 


### PR DESCRIPTION
Add Role-Based Access Control so non-admin users can get granular permissions on Maven repositories, remotes, distributions, and content.

- Add AutoAddObjPermsMixin and custom permissions (modify, repair, manage_roles) to MavenRepository, MavenRemote, MavenDistribution
- Add RolesMixin, DEFAULT_ACCESS_POLICY, and LOCKED_ROLES to all viewsets with creator/owner/viewer role tiers
- Add access policies to content and repository version viewsets
- Add migration 0010_add_rbac_permissions
- Add functional tests for RBAC across all resource types

Closes: #308

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
