### PR TITLE
fix: set pulp_type in backfill migration to avoid NOT NULL violation

### DIFF
--- a/pulp_maven/app/migrations/0011_backfill_mavenpackage.py
+++ b/pulp_maven/app/migrations/0011_backfill_mavenpackage.py
@@ -26,6 +26,7 @@ def create_packages_from_poms(apps, schema_editor):
             artifact_id=gav["artifact_id"],
             version=gav["version"],
             _pulp_domain_id=gav["_pulp_domain"],
+            defaults={"pulp_type": "maven.package"},
         )
 
         if not created:


### PR DESCRIPTION
## Summary
- Migration `0011_backfill_mavenpackage` fails with `NotNullViolation` on `core_content.pulp_type` because Django historical models skip `MasterModel.__init__`, which is where `pulp_type` gets set
- Adds `defaults={"pulp_type": "maven.package"}` to the `get_or_create` call so the value is explicitly provided on INSERT

## Test plan
- [ ] Run `django-admin migrate` on a database with existing Maven artifacts (POM files) — migration should complete without errors
- [ ] Verify created `MavenPackage` rows have `pulp_type = "maven.package"` in `core_content`

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>